### PR TITLE
changed to native camera, modify proptypes, fix imports

### DIFF
--- a/app/components/screen/index.js
+++ b/app/components/screen/index.js
@@ -47,11 +47,6 @@ class Screen extends Component {
       answer: this.props.answer && this.props.answer.data,
       validated: true,
     });
-
-    //temporary - sets whether camera surveys can be answered with a video.
-    //when false, only phots can be uploaded.
-    //should be connected to admin panel eventually.
-    this.video = false;
   }
   componentDidMount() {
     let {screen: {meta: data}, auth} = this.props;
@@ -239,8 +234,8 @@ class Screen extends Component {
 
   renderCanvas(data) {
     return data.canvasType && <CanvasSection
-            video={this.video}
-            type={data.canvasType}
+            video={(data.canvasType == 'video')}
+            type={((data.canvasType == 'video') ? 'camera' : data.canvasType)}
             config={data.canvas}
             answer={this.answer('canvas')}
             onChange={this.onCanvas}

--- a/app/widgets/canvas/CameraInput.js
+++ b/app/widgets/canvas/CameraInput.js
@@ -1,144 +1,53 @@
-import React, { Component } from 'react';
-import { StyleSheet, Image, Platform } from 'react-native';
-import { Button, View, Icon, Toast } from 'native-base';
-import PropTypes from 'prop-types';
-
-import randomString from 'random-string';
-import { RNCamera } from 'react-native-camera';
+import React, {Component} from 'react';
+import {StyleSheet, Image, Platform, TouchableOpacity, Text} from 'react-native';
+import { Button, View, Icon } from 'native-base';
 import ImagePicker from 'react-native-image-picker';
-
-const styles = StyleSheet.create({
-  body: {
-    flex: 1,
-  },
-  camera: {
-    width: '100%',
-    height: 360,
-    position: 'relative',
-  },
-  footer: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    padding: 15,
-  },
-  footerText: {
-    fontSize: 20,
-    fontWeight: '300',
-  },
-  flipButton: {
-    position: 'absolute',
-    bottom: 8,
-    left: 8,
-  },
-  pickButton: {
-    position: 'absolute',
-    bottom: 8,
-    right: 8,
-  },
-});
+import styles from '../../themes/activityTheme';
 
 export default class CameraInput extends Component {
-  componentWillMount() {
-    this.setState({
-      type: RNCamera.Constants.Type.back,
-    });
-  }
 
-  pickPhoto = () => {
-    const options = { title: 'Select Image' };
-    ImagePicker.showImagePicker(options, (response) => {
+  //props: video- indicates whether to allow user to upload videos. when videos is false, only photos can be uploaded
+  //take a new picture/video with native camera
+  take = () => {
+    const options = { mediaType: ((this.props.video) ? 'video' : 'photo'),
+                    storageOptions: {
+                        cameraRoll: true,
+                        waitUntilSaved: true,
+                    }
+                  };
+    ImagePicker.launchCamera(options, (response) => {
       if (response.didCancel) {
-        console.log('User cancelled image picker');
       } else if (response.error) {
-        console.log('Image Picker error: ', response.error);
       } else {
-        const picSource = { uri: (Platform.OS === 'ios') ? response.uri.replace('file://', '') : response.uri, filename: response.uri.split('/').pop() };
+        let picSource = {uri: (Platform.OS == 'ios') ? response.uri.replace('file://','') : response.uri, filename: response.uri.split("/").pop()};
         this.props.onChange(picSource);
       }
-    });
+    })
   }
 
-  flip = () => {
-    if (this.state.type === RNCamera.Constants.Type.back) {
-      this.setState({ type: RNCamera.Constants.Type.front });
-    } else {
-      this.setState({ type: RNCamera.Constants.Type.back });
-    }
-  }
-
-  onRetake = () => {
-    this.props.onChange(undefined);
-  }
-
-  take = () => {
-    this.takePicture();
-  }
-
-  takePicture() {
-    if (this.camera) {
-      const options = {
-        quality: 0.5,
-        fixOrientation: true,
-        forceUpOrientation: true,
-        pauseAfterCapture: true,
-      };
-      this.camera.takePictureAsync(options).then((data) => {
-        const picSource = {
-          uri: data.uri,
-          filename: `image_${randomString()}.jpg`,
-          type: this.state.type,
-        };
-        this.props.onChange(picSource);
-      }).catch((err) => {
-        Toast.show({ text: err.message, position: 'bottom', type: 'danger', buttonText: 'ok' });
-      });
-    }
-  }
 
   render() {
+    //icon depend on video/picture mode
+    let iconName = ((this.props.video) ? "video-camera" : "camera");
+
     const { answer } = this.props;
-    const { type } = this.state;
-    const pic = answer;
-    return (
-      <View style={styles.body}>
-        <View style={styles.camera}>
-          {pic && (
-          <Image
-            source={pic}
-            style={styles.camera}
-            transform={pic.type === RNCamera.Constants.Type.front ? [{
-              scaleX: -1,
-            }] : undefined}
-          />
-          ) }
-          {!pic && (
-          <View>
-            <RNCamera
-              ref={(ref) => {
-                this.camera = ref;
-              }}
-              style={styles.camera}
-              type={type}
-              flashMode={RNCamera.Constants.FlashMode.off}
-              pauseAfterCapture
-              permissionDialogTitle="Permission to use camera"
-              permissionDialogMessage="We need your permission to use your camera phone"
-            />
-            <Button style={styles.flipButton} transparent onPress={this.flip}>
-              <Icon name="reverse-camera" />
-            </Button>
-            <Button style={styles.pickButton} transparent onPress={this.pickPhoto}>
-              <Icon name="image" />
-            </Button>
+    let pic = answer;
+      return (
+        <View style={styles.body}>
+          <View style={styles.camera}>
+            {pic && this.props.video && <View
+                                style={styles.videoConfirmed}>
+                  <Icon type='Entypo' name={"check"} style={styles.greenIcon}></Icon>
+              </View> }
+            {pic && !this.props.video && <Image source={pic} style={{width: null, height: 200, flex: 1, margin: 20}}/> }
+            {!pic && <View>
+              <TouchableOpacity onPress={this.take}
+                                style={styles.takeButton}>
+                  <Icon type='Entypo' name={iconName} style={styles.redIcon}></Icon>
+              </TouchableOpacity>
+            </View> }
           </View>
-          ) }
         </View>
-      </View>
-    );
+      );
   }
 }
-
-CameraInput.propTypes = {
-  answer: PropTypes.object.isRequired,
-  onChange: PropTypes.func.isRequired,
-};

--- a/app/widgets/canvas/index.js
+++ b/app/widgets/canvas/index.js
@@ -58,12 +58,12 @@ export default class DrawingSection extends Component {
 }
 
 DrawingSection.propTypes = {
-  answer: PropTypes.object.isRequired,
+  answer: PropTypes.object,
   config: PropTypes.object,
   onChange: PropTypes.func.isRequired,
   onNextChange: PropTypes.func.isRequired,
   type: PropTypes.string.isRequired,
-  video: PropTypes.object.isRequired,
+  video: PropTypes.bool.isRequired,
 };
 
 DrawingSection.defaultProps = {


### PR DESCRIPTION
Video surveys should work now.

Changes:

- import styles, since they are alread already defined in ```themes/activityTheme.js```
- switched to native camera, this transition was lost in the move to widgets directory. 
- change video propType to bool
- answer shouldn't be a required prop, as it will always be undefined until the survey is completed

If we want to keep the camera as is, and reject this pr, make sure to add RNCamera to the package, as it is currently missing! If this pr is accepted, it isn't necessary.
