### PR TITLE
ux/enh: highlight the next or done buttons, but not the skip button

### DIFF
--- a/app/components/ActivityButtons.js
+++ b/app/components/ActivityButtons.js
@@ -24,11 +24,11 @@ const ActivityButtons = ({
       ? <ScreenButton transparent onPress={onPressPrev} text={prevLabel} />
       : <ScreenButton transparent />}
     {actionLabel
-      ? <ScreenButton onPress={onPressAction} text={actionLabel} />
+      ? <ScreenButton transparent onPress={onPressAction} text={actionLabel} />
       : <ScreenButton transparent />}
-    {nextLabel
-      ? <ScreenButton transparent onPress={onPressNext} text={nextLabel} />
-      : <ScreenButton transparent />}
+    {nextLabel !== 'Skip'
+      ? <ScreenButton onPress={onPressNext} text={nextLabel} />
+      : <ScreenButton transparent onPress={onPressNext} text={nextLabel} />}
   </View>
 );
 
@@ -46,7 +46,7 @@ ActivityButtons.propTypes = {
   prevLabel: PropTypes.string,
   actionLabel: PropTypes.string,
   onPressPrev: PropTypes.func,
-  onPressNext: PropTypes.func, 
+  onPressNext: PropTypes.func,
   onPressAction: PropTypes.func,
 };
 


### PR DESCRIPTION
Highlighting the "Next" or "Done" buttons rather than the "Skip" button