### PR TITLE
Button Transparency

### DIFF
--- a/app/components/ActivityButtons.js
+++ b/app/components/ActivityButtons.js
@@ -24,11 +24,11 @@ const ActivityButtons = ({
       ? <ScreenButton transparent onPress={onPressPrev} text={prevLabel} />
       : <ScreenButton transparent />}
     {actionLabel
-      ? <ScreenButton onPress={onPressAction} text={actionLabel} />
+      ? <ScreenButton transparent onPress={onPressAction} text={actionLabel} />
       : <ScreenButton transparent />}
-    {nextLabel
-      ? <ScreenButton transparent onPress={onPressNext} text={nextLabel} />
-      : <ScreenButton transparent />}
+    {nextLabel !== 'Skip'
+      ? <ScreenButton onPress={onPressNext} text={nextLabel} />
+      : <ScreenButton transparent onPress={onPressNext} text={nextLabel} />}
   </View>
 );
 
@@ -46,7 +46,7 @@ ActivityButtons.propTypes = {
   prevLabel: PropTypes.string,
   actionLabel: PropTypes.string,
   onPressPrev: PropTypes.func,
-  onPressNext: PropTypes.func, 
+  onPressNext: PropTypes.func,
   onPressAction: PropTypes.func,
 };
 


### PR DESCRIPTION
@akeshavan made these changes here: https://github.com/ChildMindInstitute/mindlogger-app/commit/8279e54e9e93f2074d6e4c853af9cb3d3f9587da#diff-da82f977bf2aee5c98d4690512307a55 but they were lost.

Makes the 'skip' button transparent, and the 'next' button colorful.