### PR TITLE
Revert Overwritten Changes

### DIFF
--- a/app/components/screen/index.js
+++ b/app/components/screen/index.js
@@ -49,8 +49,8 @@ class Screen extends Component {
     if (data.canvasType) {
       return (
         <CanvasSection
-          video={this.video}
-          type={data.canvasType}
+          video={(data.canvasType == 'video')}
+          type={((data.canvasType == 'video') ? 'camera' : data.canvasType)}
           config={data.canvas}
           answer={answer}
           onChange={onChange}


### PR DESCRIPTION
Same changes were introduced in https://github.com/ChildMindInstitute/mindlogger-app/pull/108/files, but lost during refactoring in March.

Sets the ```video``` and ```type``` props appropriately for camera surveys.

