### PR TITLE
Store apiHost in redux instead of global variable

### DIFF
--- a/app/components/image/Image.js
+++ b/app/components/image/Image.js
@@ -3,7 +3,8 @@ import { View, Text } from 'react-native'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { CachedImage } from 'react-native-img-cache';
-import { randomLink, fileLink } from '../../services/helper';
+import { randomLink } from '../../services/helper';
+import { fileLink } from '../../services/network';
 import { Thumbnail } from 'native-base';
 import { authSelector } from '../../state/user/user.selectors';
 

--- a/app/scenes/ChangeStudy/ChangeStudyForm.js
+++ b/app/scenes/ChangeStudy/ChangeStudyForm.js
@@ -9,13 +9,12 @@ import { reduxForm, Field, propTypes } from 'redux-form';
 import styles from './styles';
 import { FormInputItem } from '../../components/form/FormItem';
 import { colors } from '../../theme';
-import config from '../../config';
 
-const ChangeStudyForm = ({ onReset, error, handleSubmit, submitting }) => (
+const ChangeStudyForm = ({ onReset, error, handleSubmit, submitting, initialValues }) => (
   <Form>
     <Field
       component={FormInputItem}
-      placeholder={global.apiHost}
+      placeholder={initialValues.apiHost}
       placeholderTextColor={colors.secondary_50}
       name="apiHost"
       autoCapitalize="none"

--- a/app/scenes/ChangeStudy/index.js
+++ b/app/scenes/ChangeStudy/index.js
@@ -14,26 +14,15 @@ import {
   Body,
 } from 'native-base';
 import { Actions } from 'react-native-router-flux';
-import { SubmissionError } from 'redux-form';
 import styles from './styles';
-import { showToast } from '../../state/app/app.actions';
+import { showToast, setApiHost, resetApiHost } from '../../state/app/app.actions';
 import ChangeStudyForm from './ChangeStudyForm';
-import config from '../../config';
+import { apiHostSelector } from '../../state/app/app.selectors';
 
 class ChangeStudy extends Component {
-
-  storeApiHost = async (newApiHost) => {
-    try {
-      await AsyncStorage.setItem('apiHost', newApiHost);
-    } catch (error) {
-      console.log(error.message);
-    }
-  };
-
   onSubmit = (body) => {
-    global.apiHost = body.apiHost;
-    this.storeApiHost(body.apiHost);
-    const { showToast } = this.props;
+    const { showToast, setApiHost } = this.props;
+    setApiHost(body.apiHost);
     showToast({
       text: 'Study has been changed.',
       position: 'top',
@@ -44,9 +33,8 @@ class ChangeStudy extends Component {
   }
 
   onReset = () => {
-    global.apiHost = config.defaultApiHost;
-    this.storeApiHost(config.defaultApiHost)
-    const { showToast } = this.props;
+    const { showToast, resetApiHost } = this.props;
+    resetApiHost();
     showToast({
       text: 'Study has been reset.',
       position: 'top',
@@ -57,6 +45,7 @@ class ChangeStudy extends Component {
   }
 
   render() {
+    const { apiHost } = this.props;
     return (
       <Container>
         <StatusBar barStyle="light-content" />
@@ -72,7 +61,11 @@ class ChangeStudy extends Component {
           <Right />
         </Header>
         <View style={styles.container2}>
-          <ChangeStudyForm onSubmit={this.onSubmit} onReset={this.onReset} />
+          <ChangeStudyForm
+            onSubmit={this.onSubmit}
+            onReset={this.onReset}
+            initialValues={{ apiHost }}
+          />
         </View>
       </Container>
     );
@@ -81,10 +74,18 @@ class ChangeStudy extends Component {
 
 ChangeStudy.propTypes = {
   showToast: PropTypes.func.isRequired,
+  resetApiHost: PropTypes.func.isRequired,
+  setApiHost: PropTypes.func.isRequired,
 };
+
+const mapStateToProps = state => ({
+  apiHost: apiHostSelector(state),
+});
 
 const mapDispatchToProps = {
   showToast,
+  setApiHost,
+  resetApiHost,
 };
 
-export default connect(null, mapDispatchToProps)(ChangeStudy);
+export default connect(mapStateToProps, mapDispatchToProps)(ChangeStudy);

--- a/app/scenes/Login/LoginForm.js
+++ b/app/scenes/Login/LoginForm.js
@@ -7,7 +7,7 @@ import {
 } from 'native-base';
 import { reduxForm, Field, propTypes } from 'redux-form';
 import { colors } from '../../theme';
-import { FormInputItem } from '../../components/form/FormItem';
+import { FormInputItem, required } from '../../components/form/FormItem';
 import styles from './styles';
 
 const LoginForm = ({ handleSubmit, submitting, error }) => (
@@ -19,6 +19,7 @@ const LoginForm = ({ handleSubmit, submitting, error }) => (
       name="user"
       autoCapitalize="none"
       style={styles.text}
+      validate={required}
     />
     <Field
       component={FormInputItem}
@@ -28,6 +29,7 @@ const LoginForm = ({ handleSubmit, submitting, error }) => (
       autoCapitalize="none"
       style={styles.text}
       secureTextEntry
+      validate={required}
     />
     <Button style={styles.button} block onPress={handleSubmit} disabled={submitting}>
       {submitting

--- a/app/scenes/Login/index.js
+++ b/app/scenes/Login/index.js
@@ -55,9 +55,9 @@ class Login extends Component {
           <LoginForm onSubmit={this.onSubmit} />
           <View style={styles.bottomRow}>
             <TouchableOpacity onPress={this.onRegister}>
-            <Text style={styles.whiteText}>New User</Text>
+              <Text style={styles.whiteText}>New User</Text>
             </TouchableOpacity>
-            <Text style={ styles.whiteText }>{" or "}</Text>
+            <Text style={styles.whiteText}>{' or '}</Text>
             <TouchableOpacity onPress={this.onForgotPassword}>
               <Text style={styles.whiteText}>Forgot Password</Text>
             </TouchableOpacity>
@@ -73,7 +73,7 @@ class Login extends Component {
               style={styles.logo}
               source={logoImage}
             />
-        </View>
+          </View>
         </Content>
         <Footer style={styles.footer}>
           <View style={{flex: 1}}>

--- a/app/services/helper.js
+++ b/app/services/helper.js
@@ -1,5 +1,5 @@
 import RNFetchBlob from 'react-native-fetch-blob';
-import config from '../config';
+import { fileLink } from './network';
 
 export const getFileInfoAsync = (path) => {
   return RNFetchBlob.fs.stat(path);
@@ -49,10 +49,6 @@ export const atob = (input = '') => {
 
   return output;
 };
-
-export const fileLink = (file, token) => {
-  return file ? `${global.apiHost}/${file['@id']}/download?contentDisposition=inline&token=${token}` : '';
-}
 
 export const randomLink = (files, token) => {
   var rand = files[Math.floor(Math.random() * files.length)];

--- a/app/services/network.js
+++ b/app/services/network.js
@@ -1,7 +1,13 @@
 import objectToFormData from 'object-to-formdata';
 import RNFetchBlob from 'react-native-fetch-blob';
-import config from '../config';
+import { getStore } from '../store';
 import { btoa } from './helper';
+import { apiHostSelector } from '../state/app/app.selectors';
+
+const apiHost = () => {
+  const state = getStore().getState(); // Get redux state
+  return apiHostSelector(state);
+};
 
 const objectToQueryParams = obj => Object.keys(obj).map(
   key => `${encodeURIComponent(key)}=${encodeURIComponent(obj[key])}`,
@@ -12,7 +18,7 @@ export const get = (route, authToken, queryObj = {}, extraHeaders = {}) => {
     ? `?${objectToQueryParams(queryObj)}`
     : '';
 
-  const url = `${global.apiHost}/${route}${queryParams}`;
+  const url = `${apiHost()}/${route}${queryParams}`;
 
   const headers = {
     ...extraHeaders,
@@ -28,7 +34,7 @@ export const get = (route, authToken, queryObj = {}, extraHeaders = {}) => {
 };
 
 export const postFormData = (route, authToken, body, extraHeaders = {}) => {
-  const url = `${global.apiHost}/${route}`;
+  const url = `${apiHost()}/${route}`;
   const headers = {
     'Girder-Token': authToken,
     ...extraHeaders,
@@ -48,7 +54,7 @@ export const postFile = ({ authToken, file, parentType, parentId }) => {
     name: file.filename,
     size: file.size,
   });
-  const url = `${global.apiHost}/file?${queryParams}`;
+  const url = `${apiHost()}/file?${queryParams}`;
   const headers = {
     'Girder-Token': authToken,
     'Content-Type': file.type,
@@ -123,7 +129,7 @@ export const signIn = ({ user, password }) => get(
 );
 
 export const signOut = (authToken) => {
-  const url = `${global.apiHost}/user/authentication`;
+  const url = `${apiHost()}/user/authentication`;
   const headers = {
     'Girder-Token': authToken,
   };
@@ -136,7 +142,7 @@ export const signOut = (authToken) => {
 
 export const forgotPassword = (email) => {
   const queryParams = objectToQueryParams({ email });
-  const url = `${global.apiHost}/user/password/temporary?${queryParams}`;
+  const url = `${apiHost()}/user/password/temporary?${queryParams}`;
   return fetch(url, {
     method: 'put',
     mode: 'cors',
@@ -144,7 +150,7 @@ export const forgotPassword = (email) => {
 };
 
 export const signUp = (userData) => {
-  const url = `${global.apiHost}/user`;
+  const url = `${apiHost()}/user`;
   return fetch(url, {
     method: 'post',
     mode: 'cors',
@@ -153,7 +159,7 @@ export const signUp = (userData) => {
 };
 
 export const updateUserDetails = (authToken, { id, firstName, lastName, email }) => {
-  const url = `${global.apiHost}/user/${id}`;
+  const url = `${apiHost()}/user/${id}`;
   const headers = {
     'Girder-Token': authToken,
   };
@@ -170,7 +176,7 @@ export const updateUserDetails = (authToken, { id, firstName, lastName, email })
 };
 
 export const updatePassword = (authToken, oldPassword, newPassword) => {
-  const url = `${global.apiHost}/user/password`;
+  const url = `${apiHost()}/user/password`;
   const headers = {
     'Girder-Token': authToken,
   };
@@ -184,3 +190,7 @@ export const updatePassword = (authToken, oldPassword, newPassword) => {
     }),
   }).then(res => (res.status === 200 ? res.json() : Promise.reject(res)));
 };
+
+export const fileLink = (file, token) => {
+  return file ? `${apiHost()}/${file['@id']}/download?contentDisposition=inline&token=${token}` : '';
+}

--- a/app/setup.js
+++ b/app/setup.js
@@ -4,13 +4,10 @@ import { Root } from 'native-base';
 import { Actions } from 'react-native-router-flux';
 import moment from 'moment';
 import AppNavigator from './scenes/AppNavigator';
-import configureStore from './configureStore';
+import configureStore from './store';
 import { initializePushNotifications } from './services/pushNotifications';
 import { sync } from './state/app/app.actions';
 import { clearUser, fetchResponseCollectionId } from './state/user/user.actions';
-import config from './config';
-import {AsyncStorage} from 'react-native';
-import './global.js'
 
 const checkAuthToken = (store) => {
   const state = store.getState();
@@ -41,26 +38,7 @@ const setInitialScreen = (authOk) => {
   }
 };
 
-setApiHost = async () => {
-  if (global.apiHost == null) {
-    try {
-      const storedApi = await AsyncStorage.getItem('apiHost');
-      if (storedApi !== null) {
-        global.apiHost = storedApi;
-      } else {
-        global.apiHost = config.defaultApiHost;
-      }
-    } catch (error) {
-      console.log(error);
-    }
-  }
-  console.log(global.apiHost);
-};
-
 const setup = () => {
-  // Set up
-  setApiHost();
-
   const store = configureStore(() => {
     const authOk = checkAuthToken(store);
     setInitialScreen(authOk);

--- a/app/state/app/app.actions.js
+++ b/app/state/app/app.actions.js
@@ -7,6 +7,16 @@ import { clearUser } from '../user/user.actions';
 import { signOut } from '../../services/network';
 import { uploadQueueSelector } from '../responses/responses.selectors';
 import { cleanFiles } from '../../services/file';
+import APP_ACTIONS from './app.constants';
+
+export const setApiHost = hostUrl => ({
+  type: APP_ACTIONS.SET_API_HOST,
+  payload: hostUrl,
+});
+
+export const resetApiHost = () => ({
+  type: APP_ACTIONS.RESET_API_HOST,
+});
 
 export const showToast = toast => () => {
   Toast.show(toast);

--- a/app/state/app/app.constants.js
+++ b/app/state/app/app.constants.js
@@ -1,0 +1,4 @@
+export default {
+  SET_API_HOST: 'SET_API_HOST',
+  RESET_API_HOST: 'RESET_API_HOST',
+};

--- a/app/state/app/app.reducer.js
+++ b/app/state/app/app.reducer.js
@@ -1,0 +1,23 @@
+import APP_CONSTANTS from './app.constants';
+import config from '../../config';
+
+export const initialState = {
+  apiHost: config.defaultApiHost,
+};
+
+export default (state = initialState, action = {}) => {
+  switch (action.type) {
+    case APP_CONSTANTS.SET_API_HOST:
+      return {
+        ...state,
+        apiHost: action.payload,
+      };
+    case APP_CONSTANTS.RESET_API_HOST:
+      return {
+        ...state,
+        apiHost: initialState.apiHost,
+      };
+    default:
+      return state;
+  }
+};

--- a/app/state/app/app.reducer.test.js
+++ b/app/state/app/app.reducer.test.js
@@ -1,0 +1,29 @@
+import appReducer, { initialState } from './app.reducer';
+import {
+  setApiHost,
+  resetApiHost,
+} from './app.actions';
+
+jest.mock('react-native-device-info', () => { });
+jest.mock('react-native-fetch-blob', () => { });
+jest.mock('react-native-push-notification', () => { });
+jest.mock('react-native-router-flux', () => { });
+jest.mock('native-base', () => { });
+
+test('it has an initial state', () => {
+  expect(appReducer(undefined, { type: 'foo' })).toEqual(initialState);
+});
+
+test('it sets api host', () => {
+  expect(appReducer(initialState, setApiHost('foobar'))).toEqual({
+    ...initialState,
+    apiHost: 'foobar',
+  });
+});
+
+test('it resets api host', () => {
+  const state = appReducer(initialState, setApiHost('foobar'));
+  expect(appReducer(state, resetApiHost())).toEqual({
+    ...initialState,
+  });
+});

--- a/app/state/app/app.selectors.js
+++ b/app/state/app/app.selectors.js
@@ -1,0 +1,3 @@
+import * as R from 'ramda';
+
+export const apiHostSelector = R.path(['app', 'apiHost']);

--- a/app/state/root.reducer.js
+++ b/app/state/root.reducer.js
@@ -4,6 +4,7 @@ import applets from './applets/applets.reducer';
 import drawer from './drawer/drawer.reducer';
 import responses from './responses/responses.reducer';
 import user from './user/user.reducer';
+import app from './app/app.reducer';
 
 export default combineReducers({
   applets,
@@ -11,4 +12,5 @@ export default combineReducers({
   form,
   responses,
   user,
+  app,
 });

--- a/app/store.js
+++ b/app/store.js
@@ -4,6 +4,8 @@ import { persistStore, persistReducer } from 'redux-persist';
 import storage from 'redux-persist/lib/storage';
 import rootReducer from './state/root.reducer';
 
+let store;
+
 export default function configureStore(onCompletion) {
   const persistConfig = {
     key: 'root',
@@ -14,7 +16,7 @@ export default function configureStore(onCompletion) {
   const persistedReducer = persistReducer(persistConfig, rootReducer);
 
   const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose; // eslint-disable-line
-  const store = createStore(persistedReducer, {}, composeEnhancers(
+  store = createStore(persistedReducer, {}, composeEnhancers(
     applyMiddleware(thunk),
   ));
 
@@ -22,3 +24,5 @@ export default function configureStore(onCompletion) {
 
   return store;
 }
+
+export const getStore = () => store;


### PR DESCRIPTION
Redux is a good place to store values that need to be accessed throughout the app. This is because:

1. We can hook React components up to the Redux store to efficiently update them when the store updates
2. Using the `redux-persist` library we can save the values even when the user closes and reopens the app without directly accessing `AsyncStorage`
3. Plays nicely with Redux Form
4. We can easily inspect the with React Native Debugger

Accordingly I added a new "app" reducer with the `apiHost` value.

Also, I found I couldn't use the Login form because I was getting validation errors. Adding `validate={required}` fixed this.