### PR TITLE
Task/new schema transform layer

### DIFF
--- a/app/models/__tests__/ema-hbn.json
+++ b/app/models/__tests__/ema-hbn.json
@@ -1,0 +1,1594 @@
+{
+  "activities": {
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNMorning/ema_morning_schema.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNMorning/ema_morning_schema",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Activity.jsonld"
+        ],
+        "http://schema.repronim.org/preamble": [
+          {
+            "@language": "en",
+            "@value": ""
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "Morning Questions"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "https://schema.repronim.org/scoringLogic": [],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "ema_morning_schema"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "EMA: Morning"
+          }
+        ],
+        "https://schema.repronim.org/order": [
+          {
+            "@list": [
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNMorning/items/time_in_bed.jsonld"
+              },
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNMorning/items/nightmares.jsonld"
+              },
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNMorning/items/sleeping_aids.jsonld"
+              }
+            ]
+          }
+        ],
+        "https://schema.repronim.org/shuffle": [
+          {
+            "@type": "http://schema.org/Boolean",
+            "@value": false
+          }
+        ],
+        "https://schema.repronim.org/visibility": [
+          {
+            "@value": true,
+            "@index": "nightmares"
+          },
+          {
+            "@value": true,
+            "@index": "sleeping_aids"
+          },
+          {
+            "@value": true,
+            "@index": "time_in_bed"
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNEvening/ema_evening_schema.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNEvening/ema_evening_schema",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Activity.jsonld"
+        ],
+        "http://schema.repronim.org/preamble": [
+          {
+            "@language": "en",
+            "@value": ""
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "Evening Questions"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "https://schema.repronim.org/scoringLogic": [],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "ema_evening_schema"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "EMA: Evening"
+          }
+        ],
+        "https://schema.repronim.org/order": [
+          {
+            "@list": [
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNEvening/items/stressful_day.jsonld"
+              },
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNEvening/items/sources_of_stress.jsonld"
+              },
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNEvening/items/good_bad_day.jsonld"
+              },
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNEvening/items/enjoyed_day.jsonld"
+              },
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNEvening/items/energy.jsonld"
+              },
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNEvening/items/health.jsonld"
+              },
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNEvening/items/negative_event.jsonld"
+              }
+            ]
+          }
+        ],
+        "https://schema.repronim.org/shuffle": [
+          {
+            "@type": "http://schema.org/Boolean",
+            "@value": false
+          }
+        ],
+        "https://schema.repronim.org/visibility": [
+          {
+            "@value": true,
+            "@index": "energy"
+          },
+          {
+            "@value": true,
+            "@index": "enjoyed_day"
+          },
+          {
+            "@value": true,
+            "@index": "good_bad_day"
+          },
+          {
+            "@value": true,
+            "@index": "health"
+          },
+          {
+            "@value": true,
+            "@index": "negative_event"
+          },
+          {
+            "@language": "en",
+            "@value": "stressful_day",
+            "@index": "sources_of_stress"
+          },
+          {
+            "@value": true,
+            "@index": "stressful_day"
+          }
+        ]
+      }
+    ]
+  },
+  "items": {
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNMorning/items/time_in_bed.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNMorning/items/time_in_bed",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Field.jsonld"
+        ],
+        "http://schema.org/question": [
+          {
+            "@language": "en",
+            "@value": "Mark the hours that your child was in bed"
+          }
+        ],
+        "https://schema.repronim.org/valueconstraints": [
+          {}
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "time spent in bed"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "time_in_bed"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "Time in bed"
+          }
+        ],
+        "https://schema.repronim.org/inputType": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#string",
+            "@value": "timeRange"
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNMorning/items/nightmares.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNMorning/items/nightmares",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Field.jsonld"
+        ],
+        "http://schema.org/question": [
+          {
+            "@language": "en",
+            "@value": "Did your child have any nightmares or night terrors last night?"
+          }
+        ],
+        "https://schema.repronim.org/valueconstraints": [
+          {
+            "@type": [
+              "http://www.w3.org/2001/XMLSchema#anyURI"
+            ],
+            "http://schema.org/itemListElement": [
+              {
+                "@list": [
+                  {
+                    "@type": [
+                      "http://schema.org/Boolean"
+                    ],
+                    "http://schema.org/image": [
+                      {
+                        "@language": "en",
+                        "@value": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F634.svg?sanitize=true"
+                      }
+                    ],
+                    "http://schema.org/name": [
+                      {
+                        "@language": "en",
+                        "@value": "No"
+                      }
+                    ],
+                    "http://schema.org/value": [
+                      {
+                        "@value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "@type": [
+                      "http://schema.org/Boolean"
+                    ],
+                    "http://schema.org/image": [
+                      {
+                        "@language": "en",
+                        "@value": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F62B.svg?sanitize=true"
+                      }
+                    ],
+                    "http://schema.org/name": [
+                      {
+                        "@language": "en",
+                        "@value": "Yes"
+                      }
+                    ],
+                    "http://schema.org/value": [
+                      {
+                        "@value": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "http://schema.repronim.org/multipleChoice": [
+              {
+                "@type": "http://schema.org/Boolean",
+                "@value": false
+              }
+            ],
+            "http://schema.org/maxValue": [
+              {
+                "@value": 1
+              }
+            ],
+            "http://schema.org/minValue": [
+              {
+                "@value": 0
+              }
+            ]
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "whether or not your child experience nightmares or night terrors"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "nightmares"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "Nightmares"
+          }
+        ],
+        "https://schema.repronim.org/inputType": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#string",
+            "@value": "radio"
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNMorning/items/sleeping_aids.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNMorning/items/sleeping_aids",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Field.jsonld"
+        ],
+        "http://schema.org/question": [
+          {
+            "@language": "en",
+            "@value": "Did your child take sleeping pills or anything else to help their sleep last night?"
+          }
+        ],
+        "https://schema.repronim.org/valueconstraints": [
+          {
+            "@type": [
+              "http://www.w3.org/2001/XMLSchema#anyURI"
+            ],
+            "http://schema.org/itemListElement": [
+              {
+                "@list": [
+                  {
+                    "@type": [
+                      "http://schema.org/Boolean"
+                    ],
+                    "http://schema.org/image": [
+                      {
+                        "@language": "en",
+                        "@value": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F6CF.svg?sanitize=true"
+                      }
+                    ],
+                    "http://schema.org/name": [
+                      {
+                        "@language": "en",
+                        "@value": "No"
+                      }
+                    ],
+                    "http://schema.org/value": [
+                      {
+                        "@value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "@type": [
+                      "http://schema.org/Boolean"
+                    ],
+                    "http://schema.org/image": [
+                      {
+                        "@language": "en",
+                        "@value": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F48A.svg?sanitize=true"
+                      }
+                    ],
+                    "http://schema.org/name": [
+                      {
+                        "@language": "en",
+                        "@value": "Yes"
+                      }
+                    ],
+                    "http://schema.org/value": [
+                      {
+                        "@value": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "http://schema.repronim.org/multipleChoice": [
+              {
+                "@type": "http://schema.org/Boolean",
+                "@value": false
+              }
+            ],
+            "http://schema.org/maxValue": [
+              {
+                "@value": 1
+              }
+            ],
+            "http://schema.org/minValue": [
+              {
+                "@value": 0
+              }
+            ]
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "whether or not your child took sleeping aids to fall asleep last night"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "sleeping_aids"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "Sleeping Aids"
+          }
+        ],
+        "https://schema.repronim.org/inputType": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#string",
+            "@value": "radio"
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNEvening/items/stressful_day.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNEvening/items/stressful_day",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Field.jsonld"
+        ],
+        "http://schema.org/question": [
+          {
+            "@language": "en",
+            "@value": "Do you think your child had a stressful day today?"
+          }
+        ],
+        "https://schema.repronim.org/valueconstraints": [
+          {
+            "@type": [
+              "http://www.w3.org/2001/XMLSchema#anyURI"
+            ],
+            "http://schema.org/itemListElement": [
+              {
+                "@list": [
+                  {
+                    "@type": [
+                      "http://schema.org/Boolean"
+                    ],
+                    "http://schema.org/image": [
+                      {
+                        "@language": "en",
+                        "@value": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F60A.svg?sanitize=true"
+                      }
+                    ],
+                    "http://schema.org/name": [
+                      {
+                        "@language": "en",
+                        "@value": "No"
+                      }
+                    ],
+                    "http://schema.org/value": [
+                      {
+                        "@value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "@type": [
+                      "http://schema.org/Boolean"
+                    ],
+                    "http://schema.org/image": [
+                      {
+                        "@language": "en",
+                        "@value": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F630.svg?sanitize=true"
+                      }
+                    ],
+                    "http://schema.org/name": [
+                      {
+                        "@language": "en",
+                        "@value": "Yes"
+                      }
+                    ],
+                    "http://schema.org/value": [
+                      {
+                        "@value": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "http://schema.repronim.org/multipleChoice": [
+              {
+                "@type": "http://schema.org/Boolean",
+                "@value": false
+              }
+            ],
+            "http://schema.org/maxValue": [
+              {
+                "@value": 1
+              }
+            ],
+            "http://schema.org/minValue": [
+              {
+                "@value": 0
+              }
+            ]
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "whether or not your child took sleeping aids to fall asleep last night"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "stressful_day"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "Stress"
+          }
+        ],
+        "https://schema.repronim.org/inputType": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#string",
+            "@value": "radio"
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNEvening/items/sources_of_stress.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNEvening/items/sources_of_stress",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Field.jsonld"
+        ],
+        "http://schema.org/question": [
+          {
+            "@language": "en",
+            "@value": "Choose the source(s) of your child's stress today:"
+          }
+        ],
+        "https://schema.repronim.org/valueconstraints": [
+          {
+            "@type": [
+              "http://www.w3.org/2001/XMLSchema#anyURI"
+            ],
+            "http://schema.org/itemListElement": [
+              {
+                "@list": [
+                  {
+                    "@type": [
+                      "http://schema.org/option"
+                    ],
+                    "http://schema.org/image": [
+                      {
+                        "@language": "en",
+                        "@value": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F915.svg?sanitize=true"
+                      }
+                    ],
+                    "http://schema.org/name": [
+                      {
+                        "@language": "en",
+                        "@value": "Didn't feel well"
+                      }
+                    ],
+                    "http://schema.org/value": [
+                      {
+                        "@value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "@type": [
+                      "http://schema.org/option"
+                    ],
+                    "http://schema.org/image": [
+                      {
+                        "@language": "en",
+                        "@value": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F469-200D-1F3EB.svg?sanitize=true"
+                      }
+                    ],
+                    "http://schema.org/name": [
+                      {
+                        "@language": "en",
+                        "@value": "Classroom learning"
+                      }
+                    ],
+                    "http://schema.org/value": [
+                      {
+                        "@value": 1
+                      }
+                    ]
+                  },
+                  {
+                    "@type": [
+                      "http://schema.org/option"
+                    ],
+                    "http://schema.org/image": [
+                      {
+                        "@language": "en",
+                        "@value": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F4DD.svg?sanitize=true"
+                      }
+                    ],
+                    "http://schema.org/name": [
+                      {
+                        "@language": "en",
+                        "@value": "A test or quiz at school"
+                      }
+                    ],
+                    "http://schema.org/value": [
+                      {
+                        "@value": 2
+                      }
+                    ]
+                  },
+                  {
+                    "@type": [
+                      "http://schema.org/option"
+                    ],
+                    "http://schema.org/image": [
+                      {
+                        "@language": "en",
+                        "@value": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F47F.svg?sanitize=true"
+                      }
+                    ],
+                    "http://schema.org/name": [
+                      {
+                        "@language": "en",
+                        "@value": "Bullying"
+                      }
+                    ],
+                    "http://schema.org/value": [
+                      {
+                        "@value": 3
+                      }
+                    ]
+                  },
+                  {
+                    "@type": [
+                      "http://schema.org/option"
+                    ],
+                    "http://schema.org/image": [
+                      {
+                        "@language": "en",
+                        "@value": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/E246.svg?sanitize=true"
+                      }
+                    ],
+                    "http://schema.org/name": [
+                      {
+                        "@language": "en",
+                        "@value": "Online relationships"
+                      }
+                    ],
+                    "http://schema.org/value": [
+                      {
+                        "@value": 4
+                      }
+                    ]
+                  },
+                  {
+                    "@type": [
+                      "http://schema.org/option"
+                    ],
+                    "http://schema.org/image": [
+                      {
+                        "@language": "en",
+                        "@value": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/2764.svg?sanitize=true"
+                      }
+                    ],
+                    "http://schema.org/name": [
+                      {
+                        "@language": "en",
+                        "@value": "Death of a loved one"
+                      }
+                    ],
+                    "http://schema.org/value": [
+                      {
+                        "@value": 5
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "http://schema.repronim.org/multipleChoice": [
+              {
+                "@type": "http://schema.org/Boolean",
+                "@value": true
+              }
+            ],
+            "http://schema.org/maxValue": [
+              {
+                "@value": 2
+              }
+            ],
+            "http://schema.org/minValue": [
+              {
+                "@value": 0
+              }
+            ]
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "your child's sources of stress"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "source_of_stress"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "Sources of Stress"
+          }
+        ],
+        "https://schema.repronim.org/inputType": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#string",
+            "@value": "radio"
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNEvening/items/good_bad_day.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNEvening/items/good_bad_day",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Field.jsonld"
+        ],
+        "http://schema.org/question": [
+          {
+            "@language": "en",
+            "@value": "Did your child have a good day or bad day today?"
+          }
+        ],
+        "https://schema.repronim.org/valueconstraints": [
+          {
+            "@type": [
+              "http://www.w3.org/2001/XMLSchema#anyURI"
+            ],
+            "http://schema.org/itemListElement": [
+              {
+                "@list": [
+                  {
+                    "@type": [
+                      "http://schema.org/Boolean"
+                    ],
+                    "http://schema.org/image": [
+                      {
+                        "@language": "en",
+                        "@value": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F44E.svg?sanitize=true"
+                      }
+                    ],
+                    "http://schema.org/name": [
+                      {
+                        "@language": "en",
+                        "@value": "Bad Day"
+                      }
+                    ],
+                    "http://schema.org/value": [
+                      {
+                        "@value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "@type": [
+                      "http://schema.org/Boolean"
+                    ],
+                    "http://schema.org/image": [
+                      {
+                        "@language": "en",
+                        "@value": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F44D.svg?sanitize=true"
+                      }
+                    ],
+                    "http://schema.org/name": [
+                      {
+                        "@language": "en",
+                        "@value": "Good Day"
+                      }
+                    ],
+                    "http://schema.org/value": [
+                      {
+                        "@value": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "http://schema.repronim.org/multipleChoice": [
+              {
+                "@type": "http://schema.org/Boolean",
+                "@value": false
+              }
+            ],
+            "http://schema.org/maxValue": [
+              {
+                "@value": 1
+              }
+            ],
+            "http://schema.org/minValue": [
+              {
+                "@value": 0
+              }
+            ]
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "did you child have a good or bad day"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "good_bad_day"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "Good or Bad day"
+          }
+        ],
+        "https://schema.repronim.org/inputType": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#string",
+            "@value": "radio"
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNEvening/items/enjoyed_day.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNEvening/items/enjoyed_day",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Field.jsonld"
+        ],
+        "http://schema.org/question": [
+          {
+            "@language": "en",
+            "@value": "Did your child seem like they enjoyed the day?"
+          }
+        ],
+        "https://schema.repronim.org/valueconstraints": [
+          {
+            "@type": [
+              "http://www.w3.org/2001/XMLSchema#integer"
+            ],
+            "http://schema.org/itemListElement": [
+              {
+                "@list": [
+                  {
+                    "http://schema.org/image": [
+                      {
+                        "@language": "en",
+                        "@value": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F621.svg?sanitize=true"
+                      }
+                    ],
+                    "http://schema.org/name": [
+                      {
+                        "@language": "en",
+                        "@value": "0"
+                      }
+                    ],
+                    "http://schema.org/value": [
+                      {
+                        "@value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "http://schema.org/name": [
+                      {
+                        "@language": "en",
+                        "@value": "1"
+                      }
+                    ],
+                    "http://schema.org/value": [
+                      {
+                        "@value": 1
+                      }
+                    ]
+                  },
+                  {
+                    "http://schema.org/name": [
+                      {
+                        "@language": "en",
+                        "@value": "2"
+                      }
+                    ],
+                    "http://schema.org/value": [
+                      {
+                        "@value": 2
+                      }
+                    ]
+                  },
+                  {
+                    "http://schema.org/name": [
+                      {
+                        "@language": "en",
+                        "@value": "3"
+                      }
+                    ],
+                    "http://schema.org/value": [
+                      {
+                        "@value": 3
+                      }
+                    ]
+                  },
+                  {
+                    "http://schema.org/name": [
+                      {
+                        "@language": "en",
+                        "@value": "4"
+                      }
+                    ],
+                    "http://schema.org/value": [
+                      {
+                        "@value": 4
+                      }
+                    ]
+                  },
+                  {
+                    "http://schema.org/image": [
+                      {
+                        "@language": "en",
+                        "@value": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F601.svg?sanitize=true"
+                      }
+                    ],
+                    "http://schema.org/name": [
+                      {
+                        "@language": "en",
+                        "@value": "5"
+                      }
+                    ],
+                    "http://schema.org/value": [
+                      {
+                        "@value": 5
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "http://schema.repronim.org/requiredValue": [
+              {
+                "@type": "http://schema.org/Boolean",
+                "@value": false
+              }
+            ],
+            "http://schema.org/maxValue": [
+              {
+                "@language": "en",
+                "@value": "Really enjoying things"
+              }
+            ],
+            "http://schema.org/minValue": [
+              {
+                "@language": "en",
+                "@value": "No enjoyment or pleasure"
+              }
+            ]
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "whether or not your child took sleeping aids to fall asleep last night"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "enjoyed_day"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "Enjoyed the day"
+          }
+        ],
+        "https://schema.repronim.org/inputType": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#string",
+            "@value": "slider"
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNEvening/items/energy.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNEvening/items/energy",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Field.jsonld"
+        ],
+        "http://schema.org/question": [
+          {
+            "@language": "en",
+            "@value": "How tired vs energetic did you child seem today?"
+          }
+        ],
+        "https://schema.repronim.org/valueconstraints": [
+          {
+            "@type": [
+              "http://www.w3.org/2001/XMLSchema#integer"
+            ],
+            "http://schema.org/itemListElement": [
+              {
+                "@list": [
+                  {
+                    "http://schema.org/image": [
+                      {
+                        "@language": "en",
+                        "@value": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F634.svg?sanitize=true"
+                      }
+                    ],
+                    "http://schema.org/name": [
+                      {
+                        "@language": "en",
+                        "@value": "1"
+                      }
+                    ],
+                    "http://schema.org/value": [
+                      {
+                        "@value": 1
+                      }
+                    ]
+                  },
+                  {
+                    "http://schema.org/name": [
+                      {
+                        "@language": "en",
+                        "@value": "2"
+                      }
+                    ],
+                    "http://schema.org/value": [
+                      {
+                        "@value": 2
+                      }
+                    ]
+                  },
+                  {
+                    "http://schema.org/name": [
+                      {
+                        "@language": "en",
+                        "@value": "3"
+                      }
+                    ],
+                    "http://schema.org/value": [
+                      {
+                        "@value": 3
+                      }
+                    ]
+                  },
+                  {
+                    "http://schema.org/name": [
+                      {
+                        "@language": "en",
+                        "@value": "4"
+                      }
+                    ],
+                    "http://schema.org/value": [
+                      {
+                        "@value": 4
+                      }
+                    ]
+                  },
+                  {
+                    "http://schema.org/image": [
+                      {
+                        "@language": "en",
+                        "@value": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F606.svg?sanitize=true"
+                      }
+                    ],
+                    "http://schema.org/name": [
+                      {
+                        "@language": "en",
+                        "@value": "5"
+                      }
+                    ],
+                    "http://schema.org/value": [
+                      {
+                        "@value": 5
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "http://schema.repronim.org/requiredValue": [
+              {
+                "@type": "http://schema.org/Boolean",
+                "@value": false
+              }
+            ],
+            "http://schema.org/maxValue": [
+              {
+                "@language": "en",
+                "@value": "high energy"
+              }
+            ],
+            "http://schema.org/minValue": [
+              {
+                "@language": "en",
+                "@value": "very tired"
+              }
+            ]
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "how energetic your child was today"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "energy"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "Energy level"
+          }
+        ],
+        "https://schema.repronim.org/inputType": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#string",
+            "@value": "slider"
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNEvening/items/health.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNEvening/items/health",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Field.jsonld"
+        ],
+        "http://schema.org/question": [
+          {
+            "@language": "en",
+            "@value": "Was your child in good health today?"
+          }
+        ],
+        "https://schema.repronim.org/valueconstraints": [
+          {
+            "@type": [
+              "http://www.w3.org/2001/XMLSchema#anyURI"
+            ],
+            "http://schema.org/itemListElement": [
+              {
+                "@list": [
+                  {
+                    "@type": [
+                      "http://schema.org/Boolean"
+                    ],
+                    "http://schema.org/image": [
+                      {
+                        "@language": "en",
+                        "@value": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F915.svg?sanitize=true"
+                      }
+                    ],
+                    "http://schema.org/name": [
+                      {
+                        "@language": "en",
+                        "@value": "No"
+                      }
+                    ],
+                    "http://schema.org/value": [
+                      {
+                        "@value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "@type": [
+                      "http://schema.org/Boolean"
+                    ],
+                    "http://schema.org/image": [
+                      {
+                        "@language": "en",
+                        "@value": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/263A.svg?sanitize=true"
+                      }
+                    ],
+                    "http://schema.org/name": [
+                      {
+                        "@language": "en",
+                        "@value": "Yes"
+                      }
+                    ],
+                    "http://schema.org/value": [
+                      {
+                        "@value": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "http://schema.repronim.org/multipleChoice": [
+              {
+                "@type": "http://schema.org/Boolean",
+                "@value": false
+              }
+            ],
+            "http://schema.org/maxValue": [
+              {
+                "@value": 1
+              }
+            ],
+            "http://schema.org/minValue": [
+              {
+                "@value": 0
+              }
+            ]
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "was your child in good health today"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "health"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "General Health"
+          }
+        ],
+        "https://schema.repronim.org/inputType": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#string",
+            "@value": "radio"
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNEvening/items/negative_event.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNEvening/items/sleeping_aids",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Field.jsonld"
+        ],
+        "http://schema.org/question": [
+          {
+            "@language": "en",
+            "@value": "Please think of ONE event that may have affected your child the most today (positively or negatively), no matter how slightly. In what context did the event occur?"
+          }
+        ],
+        "https://schema.repronim.org/valueconstraints": [
+          {
+            "@type": [
+              "http://www.w3.org/2001/XMLSchema#anyURI"
+            ],
+            "http://schema.org/itemListElement": [
+              {
+                "@list": [
+                  {
+                    "@type": [
+                      "http://schema.org/Boolean"
+                    ],
+                    "http://schema.org/name": [
+                      {
+                        "@language": "en",
+                        "@value": "No"
+                      }
+                    ],
+                    "http://schema.org/value": [
+                      {
+                        "@value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "@type": [
+                      "http://schema.org/Boolean"
+                    ],
+                    "http://schema.org/name": [
+                      {
+                        "@language": "en",
+                        "@value": "Yes"
+                      }
+                    ],
+                    "http://schema.org/value": [
+                      {
+                        "@value": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "http://schema.repronim.org/multipleChoice": [
+              {
+                "@type": "http://schema.org/Boolean",
+                "@value": true
+              }
+            ],
+            "http://schema.org/maxValue": [
+              {
+                "@value": 1
+              }
+            ],
+            "http://schema.org/minValue": [
+              {
+                "@value": 0
+              }
+            ]
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "whether or not your child took sleeping aids to fall asleep last night"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "sleeping_aids"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "Sleeping Aids"
+          }
+        ],
+        "https://schema.repronim.org/inputType": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#string",
+            "@value": "radio"
+          }
+        ]
+      }
+    ]
+  },
+  "applet": [
+    {
+      "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activity-sets/ema-hbn/ema-hbn_schema",
+      "@type": [
+        "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/ActivitySet.jsonld"
+      ],
+      "http://schema.org/description": [
+        {
+          "@language": "en",
+          "@value": "Daily questions about your child's physical and mental health"
+        }
+      ],
+      "http://schema.org/schemaVersion": [
+        {
+          "@language": "en",
+          "@value": "0.0.1"
+        }
+      ],
+      "http://schema.org/version": [
+        {
+          "@language": "en",
+          "@value": "0.0.1"
+        }
+      ],
+      "http://www.w3.org/2004/02/skos/core#altLabel": [
+        {
+          "@language": "en",
+          "@value": "ema-hbn"
+        }
+      ],
+      "http://www.w3.org/2004/02/skos/core#prefLabel": [
+        {
+          "@language": "en",
+          "@value": "Healthy Brain Network: EMA"
+        }
+      ],
+      "https://schema.repronim.org/activity_display_name": [
+        {
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNEvening/ema_evening_schema.jsonld": [
+            {
+              "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activity-sets/ema-hbn/Evening"
+            }
+          ],
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNMorning/ema_morning_schema.jsonld": [
+            {
+              "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activity-sets/ema-hbn/Morning"
+            }
+          ]
+        }
+      ],
+      "https://schema.repronim.org/order": [
+        {
+          "@list": [
+            {
+              "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNMorning/ema_morning_schema.jsonld"
+            },
+            {
+              "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNEvening/ema_evening_schema.jsonld"
+            }
+          ]
+        }
+      ],
+      "https://schema.repronim.org/shuffle": [
+        {
+          "@type": "http://schema.org/Boolean",
+          "@value": false
+        }
+      ],
+      "https://schema.repronim.org/visibility": [
+        {
+          "@value": true,
+          "@index": "ema_evening"
+        },
+        {
+          "@value": true,
+          "@index": "ema_morning"
+        }
+      ]
+    }
+  ]
+}

--- a/app/models/__tests__/json-ld.test.js
+++ b/app/models/__tests__/json-ld.test.js
@@ -1,10 +1,14 @@
 import * as emaHbn from './ema-hbn.json';
 import * as ndaPhq from './nda-phq.json';
 import {
+  activityTransformJson,
+  appletTransformJson,
   languageListToObject,
   listToObject,
-  appletTransformJson,
-  activityTransformJson,
+  flattenIdList,
+  flattenItemList,
+  flattenValueConstraints,
+  itemTransformJson,
 } from '../json-ld';
 
 test('languageListToObject', () => {
@@ -22,24 +26,98 @@ test('listToObject', () => {
   });
 });
 
+test('flattenIdList', () => {
+  const idList = emaHbn.applet[0]['https://schema.repronim.org/order'][0]['@list'];
+  expect(flattenIdList(idList)).toEqual([
+    'https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNMorning/ema_morning_schema.jsonld',
+    'https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNEvening/ema_evening_schema.jsonld',
+  ]);
+});
+
+test('flattenItemList', () => {
+  const item = emaHbn.items['https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNMorning/items/nightmares.jsonld'][0];
+  const valueConstraints = item['https://schema.repronim.org/valueconstraints'][0];
+  const itemList = valueConstraints['http://schema.org/itemListElement'][0]['@list'];
+  expect(flattenItemList(itemList)).toEqual([
+    {
+      image: {
+        en: 'https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F634.svg?sanitize=true',
+      },
+      name: {
+        en: 'No',
+      },
+      value: 0,
+    },
+    {
+      image: {
+        en: 'https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F62B.svg?sanitize=true',
+      },
+      name: {
+        en: 'Yes',
+      },
+      value: 1,
+    },
+  ]);
+});
+
+test('flattenValueConstraints', () => {
+  const item = emaHbn.items['https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNMorning/items/nightmares.jsonld'][0];
+  const valueConstraints = item['https://schema.repronim.org/valueconstraints'][0];
+  expect(flattenValueConstraints(valueConstraints)).toEqual({
+    multipleChoice: false,
+    maxValue: 1,
+    minValue: 0,
+    itemList: [
+      {
+        image: {
+          en: 'https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F634.svg?sanitize=true',
+        },
+        name: {
+          en: 'No',
+        },
+        value: 0,
+      },
+      {
+        image: {
+          en: 'https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F62B.svg?sanitize=true',
+        },
+        name: {
+          en: 'Yes',
+        },
+        value: 1,
+      },
+    ],
+  });
+});
+
 test('appletTransformJson: ema-hbn', () => {
   const appletJson = emaHbn.applet[0];
 
   const expectedResult = {
-    description: "Daily questions about your child's physical and mental health",
-    name: 'Healthy Brain Network: EMA',
+    description: {
+      en: "Daily questions about your child's physical and mental health",
+    },
+    name: {
+      en: 'Healthy Brain Network: EMA',
+    },
     order: [
       'https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNMorning/ema_morning_schema.jsonld',
       'https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNEvening/ema_evening_schema.jsonld',
     ],
-    schemaVersion: '0.0.1',
-    version: '0.0.1',
+    schemaVersion: {
+      en: '0.0.1',
+    },
+    version: {
+      en: '0.0.1',
+    },
     shuffle: false,
     visibility: {
       ema_evening: true,
       ema_morning: true,
     },
-    altLabel: 'ema-hbn',
+    altLabel: {
+      en: 'ema-hbn',
+    },
   };
 
   expect(appletTransformJson(appletJson)).toEqual(expectedResult);
@@ -49,17 +127,17 @@ test('activityTransformJson: ema-hbn', () => {
   const activityJson = emaHbn.activities['https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNMorning/ema_morning_schema.jsonld'][0];
 
   const expectedResult = {
-    preamble: '',
-    description: 'Morning Questions',
-    name: 'EMA: Morning',
+    preamble: { en: '' },
+    description: { en: 'Morning Questions' },
+    name: { en: 'EMA: Morning' },
     order: [
       'https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNMorning/items/time_in_bed.jsonld',
       'https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNMorning/items/nightmares.jsonld',
       'https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNMorning/items/sleeping_aids.jsonld',
     ],
-    schemaVersion: '0.0.1',
+    schemaVersion: { en: '0.0.1' },
     image: undefined,
-    version: '0.0.1',
+    version: { en: '0.0.1' },
     shuffle: false,
     visibility: {
       nightmares: true,
@@ -67,7 +145,7 @@ test('activityTransformJson: ema-hbn', () => {
       time_in_bed: true,
     },
     scoringLogic: [],
-    altLabel: 'ema_morning_schema',
+    altLabel: { en: 'ema_morning_schema' },
     allowDoNotKnow: false,
     allowRefuseToAnswer: false,
     info: undefined,
@@ -83,9 +161,13 @@ test('activityTransformJson: nda-phq', () => {
   const expectedResult = {
     allowDoNotKnow: false,
     allowRefuseToAnswer: true,
-    altLabel: 'nda_guid',
-    description: 'schema describing terms needed to generate NDA guid',
-    name: 'NDA guid',
+    altLabel: { en: 'nda_guid' },
+    description: {
+      en: 'schema describing terms needed to generate NDA guid',
+    },
+    name: {
+      en: 'NDA guid',
+    },
     order: [
       'https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/yearOfBirth.jsonld',
       'https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/raceEthnicity.jsonld',
@@ -99,10 +181,10 @@ test('activityTransformJson: nda-phq', () => {
     ],
     preamble: undefined,
     image: undefined,
-    schemaVersion: '0.0.1',
+    schemaVersion: { en: '0.0.1' },
     scoringLogic: undefined,
     shuffle: false,
-    version: '0.0.1',
+    version: { en: '0.0.1' },
     visibility: {
       countryOfBirth: true,
       gender: true,
@@ -119,4 +201,43 @@ test('activityTransformJson: nda-phq', () => {
   };
 
   expect(activityTransformJson(activityJson)).toEqual(expectedResult);
+});
+
+test('itemTransformJson', () => {
+  const item = emaHbn.items['https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNMorning/items/nightmares.jsonld'][0];
+  expect(itemTransformJson(item)).toEqual({
+    name: { en: 'Nightmares' },
+    description: { en: 'whether or not your child experience nightmares or night terrors' },
+    schemaVersion: { en: '0.0.1' },
+    version: { en: '0.0.1' },
+    altLabel: { en: 'nightmares' },
+    inputType: 'radio',
+    question: { en: 'Did your child have any nightmares or night terrors last night?' },
+    preamble: undefined,
+    valueConstraints: {
+      multipleChoice: false,
+      maxValue: 1,
+      minValue: 0,
+      itemList: [
+        {
+          image: {
+            en: 'https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F634.svg?sanitize=true',
+          },
+          name: {
+            en: 'No',
+          },
+          value: 0,
+        },
+        {
+          image: {
+            en: 'https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F62B.svg?sanitize=true',
+          },
+          name: {
+            en: 'Yes',
+          },
+          value: 1,
+        },
+      ],
+    },
+  });
 });

--- a/app/models/__tests__/json-ld.test.js
+++ b/app/models/__tests__/json-ld.test.js
@@ -1,0 +1,122 @@
+import * as emaHbn from './ema-hbn.json';
+import * as ndaPhq from './nda-phq.json';
+import {
+  languageListToObject,
+  listToObject,
+  appletTransformJson,
+  activityTransformJson,
+} from '../json-ld';
+
+test('languageListToObject', () => {
+  const languageList = emaHbn.applet[0]['http://schema.org/description'];
+  expect(languageListToObject(languageList)).toEqual({
+    en: 'Daily questions about your child\'s physical and mental health',
+  });
+});
+
+test('listToObject', () => {
+  const languageList = emaHbn.applet[0]['https://schema.repronim.org/visibility'];
+  expect(listToObject(languageList)).toEqual({
+    ema_evening: true,
+    ema_morning: true,
+  });
+});
+
+test('appletTransformJson: ema-hbn', () => {
+  const appletJson = emaHbn.applet[0];
+
+  const expectedResult = {
+    description: "Daily questions about your child's physical and mental health",
+    name: 'Healthy Brain Network: EMA',
+    order: [
+      'https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNMorning/ema_morning_schema.jsonld',
+      'https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNEvening/ema_evening_schema.jsonld',
+    ],
+    schemaVersion: '0.0.1',
+    version: '0.0.1',
+    shuffle: false,
+    visibility: {
+      ema_evening: true,
+      ema_morning: true,
+    },
+    altLabel: 'ema-hbn',
+  };
+
+  expect(appletTransformJson(appletJson)).toEqual(expectedResult);
+});
+
+test('activityTransformJson: ema-hbn', () => {
+  const activityJson = emaHbn.activities['https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNMorning/ema_morning_schema.jsonld'][0];
+
+  const expectedResult = {
+    preamble: '',
+    description: 'Morning Questions',
+    name: 'EMA: Morning',
+    order: [
+      'https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNMorning/items/time_in_bed.jsonld',
+      'https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNMorning/items/nightmares.jsonld',
+      'https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNMorning/items/sleeping_aids.jsonld',
+    ],
+    schemaVersion: '0.0.1',
+    image: undefined,
+    version: '0.0.1',
+    shuffle: false,
+    visibility: {
+      nightmares: true,
+      sleeping_aids: true,
+      time_in_bed: true,
+    },
+    scoringLogic: [],
+    altLabel: 'ema_morning_schema',
+    allowDoNotKnow: false,
+    allowRefuseToAnswer: false,
+    info: undefined,
+    notification: {},
+  };
+
+  expect(activityTransformJson(activityJson)).toEqual(expectedResult);
+});
+
+test('activityTransformJson: nda-phq', () => {
+  const activityJson = ndaPhq.activities['https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/nda_guid.jsonld'][0];
+
+  const expectedResult = {
+    allowDoNotKnow: false,
+    allowRefuseToAnswer: true,
+    altLabel: 'nda_guid',
+    description: 'schema describing terms needed to generate NDA guid',
+    name: 'NDA guid',
+    order: [
+      'https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/yearOfBirth.jsonld',
+      'https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/raceEthnicity.jsonld',
+      'https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/gender.jsonld',
+      'https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/state.jsonld',
+      'https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/countryOfBirth.jsonld',
+      'https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/nativeLanguage.jsonld',
+      'https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/mentalHealth.jsonld',
+      'https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/healthCondition.jsonld',
+      'https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/medication.jsonld',
+    ],
+    preamble: undefined,
+    image: undefined,
+    schemaVersion: '0.0.1',
+    scoringLogic: undefined,
+    shuffle: false,
+    version: '0.0.1',
+    visibility: {
+      countryOfBirth: true,
+      gender: true,
+      healthCondition: true,
+      medication: true,
+      mentalHealth: true,
+      nativeLanguage: true,
+      raceEthnicity: true,
+      state: true,
+      yearOfBirth: true,
+    },
+    info: undefined,
+    notification: {},
+  };
+
+  expect(activityTransformJson(activityJson)).toEqual(expectedResult);
+});

--- a/app/models/__tests__/nda-phq.json
+++ b/app/models/__tests__/nda-phq.json
@@ -1,0 +1,3597 @@
+{
+  "activities": {
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/nda_guid.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/nda_guid",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Activity.jsonld"
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "schema describing terms needed to generate NDA guid"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "nda_guid"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "NDA guid"
+          }
+        ],
+        "https://schema.repronim.org/allow": [
+          {
+            "@list": [
+              {
+                "@id": "https://schema.repronim.org/refused_to_answer"
+              }
+            ]
+          }
+        ],
+        "https://schema.repronim.org/order": [
+          {
+            "@list": [
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/yearOfBirth.jsonld"
+              },
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/raceEthnicity.jsonld"
+              },
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/gender.jsonld"
+              },
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/state.jsonld"
+              },
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/countryOfBirth.jsonld"
+              },
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/nativeLanguage.jsonld"
+              },
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/mentalHealth.jsonld"
+              },
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/healthCondition.jsonld"
+              },
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/medication.jsonld"
+              }
+            ]
+          }
+        ],
+        "https://schema.repronim.org/shuffle": [
+          {
+            "@type": "http://schema.org/Boolean",
+            "@value": false
+          }
+        ],
+        "https://schema.repronim.org/visibility": [
+          {
+            "@value": true,
+            "@index": "countryOfBirth"
+          },
+          {
+            "@value": true,
+            "@index": "gender"
+          },
+          {
+            "@value": true,
+            "@index": "healthCondition"
+          },
+          {
+            "@value": true,
+            "@index": "medication"
+          },
+          {
+            "@value": true,
+            "@index": "mentalHealth"
+          },
+          {
+            "@value": true,
+            "@index": "nativeLanguage"
+          },
+          {
+            "@value": true,
+            "@index": "raceEthnicity"
+          },
+          {
+            "@value": true,
+            "@index": "state"
+          },
+          {
+            "@value": true,
+            "@index": "yearOfBirth"
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/phq9_schema.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/phq9_schema",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Activity.jsonld"
+        ],
+        "http://schema.repronim.org/preamble": [
+          {
+            "@language": "en",
+            "@value": "Over the last 2 weeks, how often have you been bothered by any of the following problems?"
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "PHQ-9 assessment schema"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "https://schema.repronim.org/scoringLogic": [
+          {
+            "@language": "en",
+            "@value": "phq9_1 + phq9_2 + phq9_3 + phq9_4 + phq9_5 + phq9_6 + phq9_7 + phq9_8 + phq9_9",
+            "@index": "phq9_total_score"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "phq9_schema"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "PHQ-9 Assessment"
+          }
+        ],
+        "https://schema.repronim.org/variableMap": [
+          {
+            "@list": [
+              {
+                "https://schema.repronim.org/isAbout": [
+                  {
+                    "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_1.jsonld"
+                  }
+                ],
+                "https://schema.repronim.org/variableName": [
+                  {
+                    "@language": "en",
+                    "@value": "phq9_1"
+                  }
+                ]
+              },
+              {
+                "https://schema.repronim.org/isAbout": [
+                  {
+                    "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_2.jsonld"
+                  }
+                ],
+                "https://schema.repronim.org/variableName": [
+                  {
+                    "@language": "en",
+                    "@value": "phq9_2"
+                  }
+                ]
+              },
+              {
+                "https://schema.repronim.org/isAbout": [
+                  {
+                    "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_3.jsonld"
+                  }
+                ],
+                "https://schema.repronim.org/variableName": [
+                  {
+                    "@language": "en",
+                    "@value": "phq9_3"
+                  }
+                ]
+              },
+              {
+                "https://schema.repronim.org/isAbout": [
+                  {
+                    "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_4.jsonld"
+                  }
+                ],
+                "https://schema.repronim.org/variableName": [
+                  {
+                    "@language": "en",
+                    "@value": "phq9_4"
+                  }
+                ]
+              },
+              {
+                "https://schema.repronim.org/isAbout": [
+                  {
+                    "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_5.jsonld"
+                  }
+                ],
+                "https://schema.repronim.org/variableName": [
+                  {
+                    "@language": "en",
+                    "@value": "phq9_5"
+                  }
+                ]
+              },
+              {
+                "https://schema.repronim.org/isAbout": [
+                  {
+                    "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_6.jsonld"
+                  }
+                ],
+                "https://schema.repronim.org/variableName": [
+                  {
+                    "@language": "en",
+                    "@value": "phq9_6"
+                  }
+                ]
+              },
+              {
+                "https://schema.repronim.org/isAbout": [
+                  {
+                    "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_7.jsonld"
+                  }
+                ],
+                "https://schema.repronim.org/variableName": [
+                  {
+                    "@language": "en",
+                    "@value": "phq9_7"
+                  }
+                ]
+              },
+              {
+                "https://schema.repronim.org/isAbout": [
+                  {
+                    "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_8.jsonld"
+                  }
+                ],
+                "https://schema.repronim.org/variableName": [
+                  {
+                    "@language": "en",
+                    "@value": "phq9_8"
+                  }
+                ]
+              },
+              {
+                "https://schema.repronim.org/isAbout": [
+                  {
+                    "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_9.jsonld"
+                  }
+                ],
+                "https://schema.repronim.org/variableName": [
+                  {
+                    "@language": "en",
+                    "@value": "phq9_9"
+                  }
+                ]
+              },
+              {
+                "https://schema.repronim.org/isAbout": [
+                  {
+                    "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_10.jsonld"
+                  }
+                ],
+                "https://schema.repronim.org/variableName": [
+                  {
+                    "@language": "en",
+                    "@value": "phq9_10"
+                  }
+                ]
+              },
+              {
+                "https://schema.repronim.org/isAbout": [
+                  {
+                    "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_total_score.jsonld"
+                  }
+                ],
+                "https://schema.repronim.org/variableName": [
+                  {
+                    "@language": "en",
+                    "@value": "phq9_total_score"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "https://schema.repronim.org/order": [
+          {
+            "@list": [
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_1.jsonld"
+              },
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_2.jsonld"
+              },
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_3.jsonld"
+              },
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_4.jsonld"
+              },
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_5.jsonld"
+              },
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_6.jsonld"
+              },
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_7.jsonld"
+              },
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_8.jsonld"
+              },
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_9.jsonld"
+              },
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_10.jsonld"
+              }
+            ]
+          }
+        ],
+        "https://schema.repronim.org/shuffle": [
+          {
+            "@type": "http://schema.org/Boolean",
+            "@value": false
+          }
+        ],
+        "https://schema.repronim.org/visibility": [
+          {
+            "@value": true,
+            "@index": "phq9_1"
+          },
+          {
+            "@language": "en",
+            "@value": "phq9_1 > 0 ||  phq9_2 > 0 || phq9_3 > 0 || phq9_4 > 0 || phq9_5 > 0 || phq9_6 > 0 || phq9_7 > 0 || phq9_8 > 0 || phq9_9 > 0",
+            "@index": "phq9_10"
+          },
+          {
+            "@value": true,
+            "@index": "phq9_2"
+          },
+          {
+            "@value": true,
+            "@index": "phq9_3"
+          },
+          {
+            "@value": true,
+            "@index": "phq9_4"
+          },
+          {
+            "@value": true,
+            "@index": "phq9_5"
+          },
+          {
+            "@value": true,
+            "@index": "phq9_6"
+          },
+          {
+            "@value": true,
+            "@index": "phq9_7"
+          },
+          {
+            "@value": true,
+            "@index": "phq9_8"
+          },
+          {
+            "@value": true,
+            "@index": "phq9_9"
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/phq9a_schema.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/phq9a_schema",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Activity.jsonld"
+        ],
+        "https://schema.repronim.org/branchLogic": [
+          {
+            "@language": "en",
+            "@value": "if (phq9a_1 != 0 | phq9a_2 != 0 | phq9a_3 !=0 | phq9a_4 !=0 | phq9a_5 !=0 | phq9a_6 !=0 | phq9a_7 !=0 | phq9a_8 !=0 | phq9a_9 != 0) { phq9a_10.ui.hidden = false }",
+            "@index": "javascript"
+          }
+        ],
+        "http://schema.repronim.org/preamble": [
+          {
+            "@language": "en",
+            "@value": "Over the last 1 week, how often have you been bothered by any of the following problems? (Use \\u201c\\u2714\\u201d to indicate your answer)"
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "PHQ-9a assessment schema"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "https://schema.repronim.org/scoringLogic": [
+          {
+            "@language": "en",
+            "@value": "phq9a_total_score = phq9a_1 + phq9a_2 + phq9a_3 + phq9a_4 + phq9a_5 + phq9a_6 + phq9a_7 + phq9a_8 + phq9a_9",
+            "@index": "javascript"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "phq9a_schema"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "PHQ-9a Assessment"
+          }
+        ],
+        "https://schema.repronim.org/order": [
+          {
+            "@list": [
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/items/phq9a_1.jsonld"
+              },
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/items/phq9a_2.jsonld"
+              },
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/items/phq9a_3.jsonld"
+              },
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/items/phq9a_4.jsonld"
+              },
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/items/phq9a_5.jsonld"
+              },
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/items/phq9a_6.jsonld"
+              },
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/items/phq9a_7.jsonld"
+              },
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/items/phq9a_8.jsonld"
+              },
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/items/phq9a_9.jsonld"
+              },
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/items/phq9a_10.jsonld"
+              }
+            ]
+          }
+        ],
+        "https://schema.repronim.org/shuffle": [
+          {
+            "@type": "http://schema.org/Boolean",
+            "@value": false
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-8/phq8_schema.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-8/phq8_schema",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Activity.jsonld"
+        ],
+        "https://schema.repronim.org/branchLogic": [
+          {
+            "@language": "en",
+            "@value": "if (phq8_1 != 0 | phq8_2 != 0 | phq8_3 !=0 | phq8_4 !=0 | phq8_5 !=0 | phq8_6 !=0 | phq8_7 !=0 | phq8_8 !=0) { phq8_10.ui.hidden = false }",
+            "@index": "javascript"
+          }
+        ],
+        "http://schema.repronim.org/preamble": [
+          {
+            "@language": "en",
+            "@value": "Over the last 2 weeks, how often have you been bothered by any of the following problems? (Use \\u201c\\u2714\\u201d to indicate your answer)"
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "PHQ-8 assessment schema"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "https://schema.repronim.org/scoringLogic": [
+          {
+            "@language": "en",
+            "@value": "phq8_total_score = phq8_1 + phq8_2 + phq8_3 + phq8_4 + phq8_5 + phq8_6 + phq8_7 + phq8_8",
+            "@index": "javascript"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "phq8_schema"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "PHQ-8 Assessment"
+          }
+        ],
+        "https://schema.repronim.org/order": [
+          {
+            "@list": [
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-8/items/phq8_1.jsonld"
+              },
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-8/items/phq8_2.jsonld"
+              },
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-8/items/phq8_3.jsonld"
+              },
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-8/items/phq8_4.jsonld"
+              },
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-8/items/phq8_5.jsonld"
+              },
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-8/items/phq8_6.jsonld"
+              },
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-8/items/phq8_7.jsonld"
+              },
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-8/items/phq8_8.jsonld"
+              }
+            ]
+          }
+        ],
+        "https://schema.repronim.org/shuffle": [
+          {
+            "@type": "http://schema.org/Boolean",
+            "@value": false
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/voice_task/voice_task_schema.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/voice_task/voice_task_schema",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Activity.jsonld"
+        ],
+        "https://schema.repronim.org/branchLogic": [],
+        "http://schema.repronim.org/preamble": [
+          {
+            "@language": "en",
+            "@value": "For each task, you should hit the record button before speaking and then stop once you are done speaking. You may hit play to hear what was recorded."
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "Voice tasks"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "https://schema.repronim.org/scoringLogic": [],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "voice tasks"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "voice tasks"
+          }
+        ],
+        "https://schema.repronim.org/allow": [
+          {
+            "@list": [
+              {
+                "@id": "https://schema.repronim.org/refused_to_answer"
+              },
+              {
+                "@id": "https://schema.repronim.org/dont_know_answer"
+              }
+            ]
+          }
+        ],
+        "https://schema.repronim.org/order": [
+          {
+            "@list": [
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/voice_task/items/say_ah.jsonld"
+              },
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/voice_task/items/pataka.jsonld"
+              },
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/voice_task/items/guided_speech.jsonld"
+              },
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/voice_task/items/free_speech.jsonld"
+              },
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/voice_task/items/describe_image.jsonld"
+              },
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/voice_task/multipart_voice_schema.jsonld"
+              },
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/voice_task/items/phonetic.jsonld"
+              },
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/voice_task/items/rainbow_passage.jsonld"
+              }
+            ]
+          }
+        ],
+        "https://schema.repronim.org/shuffle": [
+          {
+            "@type": "http://schema.org/Boolean",
+            "@value": false
+          }
+        ]
+      }
+    ]
+  },
+  "items": {
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/yearOfBirth.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/birthYear",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Field.jsonld"
+        ],
+        "http://schema.org/question": [
+          {
+            "@language": "en",
+            "@value": "Year of birth"
+          }
+        ],
+        "https://schema.repronim.org/valueconstraints": [
+          {
+            "http://schema.repronim.org/requiredValue": [
+              {
+                "@type": "http://schema.org/Boolean",
+                "@value": true
+              }
+            ],
+            "http://schema.org/maxValue": [
+              {
+                "@language": "en",
+                "@value": "new Date()"
+              }
+            ]
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "schema for Year of birth YYYY"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "birthYear"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "year of birth"
+          }
+        ],
+        "https://schema.repronim.org/inputType": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#string",
+            "@value": "date"
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/raceEthnicity.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/raceEthnicity",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Field.jsonld"
+        ],
+        "http://schema.org/question": [
+          {
+            "@language": "en",
+            "@value": "Race/Ethnicity"
+          }
+        ],
+        "https://schema.repronim.org/valueconstraints": [
+          {
+            "http://schema.org/itemListElement": [
+              {
+                "@list": [
+                  {
+                    "http://schema.org/name": [
+                      {
+                        "@language": "en",
+                        "@value": "American Indian or Alaska Native"
+                      }
+                    ],
+                    "http://schema.org/value": [
+                      {
+                        "@value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "http://schema.org/name": [
+                      {
+                        "@language": "en",
+                        "@value": "Asian"
+                      }
+                    ],
+                    "http://schema.org/value": [
+                      {
+                        "@value": 1
+                      }
+                    ]
+                  },
+                  {
+                    "http://schema.org/name": [
+                      {
+                        "@language": "en",
+                        "@value": "Black or African American"
+                      }
+                    ],
+                    "http://schema.org/value": [
+                      {
+                        "@value": 2
+                      }
+                    ]
+                  },
+                  {
+                    "http://schema.org/name": [
+                      {
+                        "@language": "en",
+                        "@value": "Native Hawaiian or Other Pacific Islander"
+                      }
+                    ],
+                    "http://schema.org/value": [
+                      {
+                        "@value": 3
+                      }
+                    ]
+                  },
+                  {
+                    "http://schema.org/name": [
+                      {
+                        "@language": "en",
+                        "@value": "White"
+                      }
+                    ],
+                    "http://schema.org/value": [
+                      {
+                        "@value": 4
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "http://schema.repronim.org/requiredValue": [
+              {
+                "@type": "http://schema.org/Boolean",
+                "@value": false
+              }
+            ]
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "schema for race or Ethnicity of participant"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "raceEthnicity"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "Race or Ethnicity"
+          }
+        ],
+        "https://schema.repronim.org/inputType": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#string",
+            "@value": "select"
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/gender.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/gender",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Field.jsonld"
+        ],
+        "http://schema.org/question": [
+          {
+            "@language": "en",
+            "@value": "Sex"
+          }
+        ],
+        "https://schema.repronim.org/valueconstraints": [
+          {
+            "@type": [
+              "http://www.w3.org/2001/XMLSchema#anyURI"
+            ],
+            "http://schema.org/itemListElement": [
+              {
+                "@list": [
+                  {
+                    "@type": [
+                      "http://schema.org/Female"
+                    ],
+                    "http://schema.org/name": [
+                      {
+                        "@language": "en",
+                        "@value": "Female"
+                      }
+                    ],
+                    "http://schema.org/value": [
+                      {
+                        "@value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "@type": [
+                      "http://schema.org/Male"
+                    ],
+                    "http://schema.org/name": [
+                      {
+                        "@language": "en",
+                        "@value": "Male"
+                      }
+                    ],
+                    "http://schema.org/value": [
+                      {
+                        "@value": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "http://schema.repronim.org/multipleChoice": [
+              {
+                "@type": "http://schema.org/Boolean",
+                "@value": false
+              }
+            ],
+            "http://schema.repronim.org/requiredValue": [
+              {
+                "@type": "http://schema.org/Boolean",
+                "@value": true
+              }
+            ],
+            "http://schema.org/maxValue": [
+              {
+                "@value": 1
+              }
+            ],
+            "http://schema.org/minValue": [
+              {
+                "@value": 0
+              }
+            ]
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "schema for Sex of the subject"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "gender"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "Sex of the subject"
+          }
+        ],
+        "https://schema.repronim.org/inputType": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#string",
+            "@value": "radio"
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/state.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/state",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Field.jsonld"
+        ],
+        "http://schema.org/question": [
+          {
+            "@language": "en",
+            "@value": "State of residence"
+          }
+        ],
+        "https://schema.repronim.org/valueconstraints": [
+          {
+            "http://schema.repronim.org/requiredValue": [
+              {
+                "@type": "http://schema.org/Boolean",
+                "@value": false
+              }
+            ]
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "schema for state of residence of participant"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "state"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "State of residence"
+          }
+        ],
+        "https://schema.repronim.org/inputType": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#string",
+            "@value": "select"
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/countryOfBirth.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/birthCountry",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Field.jsonld"
+        ],
+        "http://schema.org/question": [
+          {
+            "@language": "en",
+            "@value": "Country of birth"
+          }
+        ],
+        "https://schema.repronim.org/valueconstraints": [
+          {
+            "http://schema.repronim.org/requiredValue": [
+              {
+                "@type": "http://schema.org/Boolean",
+                "@value": true
+              }
+            ]
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "schema for Country of birth of participant"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "birthCountry"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "Country of birth(as in birth certificate)"
+          }
+        ],
+        "https://schema.repronim.org/inputType": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#string",
+            "@value": "select"
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/nativeLanguage.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/nativeLanguage",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Field.jsonld"
+        ],
+        "http://schema.org/question": [
+          {
+            "@language": "en",
+            "@value": "Native Language"
+          }
+        ],
+        "https://schema.repronim.org/valueconstraints": [
+          {
+            "http://schema.repronim.org/requiredValue": [
+              {
+                "@type": "http://schema.org/Boolean",
+                "@value": false
+              }
+            ]
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "schema for native language of participant"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "nativeLanguage"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "Native language of participant"
+          }
+        ],
+        "https://schema.repronim.org/inputType": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#string",
+            "@value": "select"
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/mentalHealth.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/mental_health",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Field.jsonld"
+        ],
+        "http://schema.org/question": [
+          {
+            "@language": "en",
+            "@value": "Diagnosed with any mental-health disorder?"
+          }
+        ],
+        "https://schema.repronim.org/valueconstraints": [
+          {}
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "schema for mental health of participant"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "mental_health"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "mental health diagnosis of participant"
+          }
+        ],
+        "https://schema.repronim.org/inputType": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#string",
+            "@value": "text"
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/healthCondition.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/health_condition",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Field.jsonld"
+        ],
+        "http://schema.org/question": [
+          {
+            "@language": "en",
+            "@value": "Any health condition?"
+          }
+        ],
+        "https://schema.repronim.org/valueconstraints": [
+          {}
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "schema for health condition information of participant"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "health_condition"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "Health Condition of participant"
+          }
+        ],
+        "https://schema.repronim.org/inputType": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#string",
+            "@value": "text"
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/medication.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/medication",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Field.jsonld"
+        ],
+        "http://schema.org/question": [
+          {
+            "@language": "en",
+            "@value": "Medication"
+          }
+        ],
+        "https://schema.repronim.org/valueconstraints": [
+          {}
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "schema for medication of participant"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "medication"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "medication of participant"
+          }
+        ],
+        "https://schema.repronim.org/inputType": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#string",
+            "@value": "text"
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_1.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_1",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Field.jsonld"
+        ],
+        "http://schema.org/question": [
+          {
+            "@language": "en",
+            "@value": "Little interest or pleasure in doing things"
+          }
+        ],
+        "https://schema.repronim.org/valueconstraints": [
+          {
+            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/valueConstraints.jsonld"
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "Q1 of the PHQ-9 Assessment"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "phq9_1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "Q1 of PHQ-9 Questionnaire"
+          }
+        ],
+        "https://schema.repronim.org/inputType": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#string",
+            "@value": "radio"
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_2.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_2",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Field.jsonld"
+        ],
+        "http://schema.org/question": [
+          {
+            "@language": "en",
+            "@value": "Feeling down, depressed or hopeless?"
+          }
+        ],
+        "https://schema.repronim.org/valueconstraints": [
+          {
+            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/valueConstraints.jsonld"
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "Q2 of the PHQ-9 Assessment"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "phq9_2"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "Q2 of PHQ-9 Questionnaire"
+          }
+        ],
+        "https://schema.repronim.org/inputType": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#string",
+            "@value": "radio"
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_3.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_3",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Field.jsonld"
+        ],
+        "http://schema.org/question": [
+          {
+            "@language": "en",
+            "@value": "Trouble falling or staying asleep, or sleeping too much?"
+          }
+        ],
+        "https://schema.repronim.org/valueconstraints": [
+          {
+            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/valueConstraints.jsonld"
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "Q3 of the PHQ-9 Assessment"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "phq9_3"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "Q3 of PHQ-9 Questionnaire"
+          }
+        ],
+        "https://schema.repronim.org/inputType": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#string",
+            "@value": "radio"
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_4.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_4",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Field.jsonld"
+        ],
+        "http://schema.org/question": [
+          {
+            "@language": "en",
+            "@value": "Feeling tired or having little energy?"
+          }
+        ],
+        "https://schema.repronim.org/valueconstraints": [
+          {
+            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/valueConstraints.jsonld"
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "Q4 of the PHQ-9 Assessment"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "phq9_4"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "Q4 of PHQ-9 Questionnaire"
+          }
+        ],
+        "https://schema.repronim.org/inputType": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#string",
+            "@value": "radio"
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_5.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_5",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Field.jsonld"
+        ],
+        "http://schema.org/question": [
+          {
+            "@language": "en",
+            "@value": "Poor appetite or overeating?"
+          }
+        ],
+        "https://schema.repronim.org/valueconstraints": [
+          {
+            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/valueConstraints.jsonld"
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "schema for Q5 of the PHQ-9 Assessment"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "phq9_5"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "Q5 of PHQ-9 Questionnaire"
+          }
+        ],
+        "https://schema.repronim.org/inputType": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#string",
+            "@value": "radio"
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_6.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_6",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Field.jsonld"
+        ],
+        "http://schema.org/question": [
+          {
+            "@language": "en",
+            "@value": "Feeling bad about yourself \\u2014 or that you are a failure or have let yourself or your family down?"
+          }
+        ],
+        "https://schema.repronim.org/valueconstraints": [
+          {
+            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/valueConstraints.jsonld"
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "schema for Q6 of the PHQ-9 Assessment"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "phq9_6"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "Q6 of PHQ-9 Questionnaire"
+          }
+        ],
+        "https://schema.repronim.org/inputType": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#string",
+            "@value": "radio"
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_7.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_7",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Field.jsonld"
+        ],
+        "http://schema.org/question": [
+          {
+            "@language": "en",
+            "@value": "Trouble concentrating on things, such as reading the newspaper or watching television?"
+          }
+        ],
+        "https://schema.repronim.org/valueconstraints": [
+          {
+            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/valueConstraints.jsonld"
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "schema for Q7 of the PHQ-9 Assessment"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "phq9_7"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "Q7 of PHQ-9 Questionnaire"
+          }
+        ],
+        "https://schema.repronim.org/inputType": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#string",
+            "@value": "radio"
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_8.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_8",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Field.jsonld"
+        ],
+        "http://schema.org/question": [
+          {
+            "@language": "en",
+            "@value": "Moving or speaking so slowly that other people could have noticed? Or the opposite \\u2014 being so fidgety or restless that you have been moving around a lot more than usual?"
+          }
+        ],
+        "https://schema.repronim.org/valueconstraints": [
+          {
+            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/valueConstraints.jsonld"
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "schema for Q8 of the PHQ-9 Assessment"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "phq9_8"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "Q8 of PHQ-9 Questionnaire"
+          }
+        ],
+        "https://schema.repronim.org/inputType": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#string",
+            "@value": "radio"
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_9.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_9",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Field.jsonld"
+        ],
+        "http://schema.org/question": [
+          {
+            "@language": "en",
+            "@value": "Thoughts that you would be better off dead or of hurting yourself in some way?"
+          }
+        ],
+        "https://schema.repronim.org/valueconstraints": [
+          {
+            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/valueConstraints.jsonld"
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "schema for Q9 of the PHQ-9 Assessment"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "phq9_9"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "Q9 of PHQ-9 Questionnaire"
+          }
+        ],
+        "https://schema.repronim.org/inputType": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#string",
+            "@value": "radio"
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_10.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_10",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Field.jsonld"
+        ],
+        "http://schema.org/question": [
+          {
+            "@language": "en",
+            "@value": "How difficult have these problems made it for you to do your work, take care of things at home, or get along with other people?"
+          }
+        ],
+        "https://schema.repronim.org/valueconstraints": [
+          {
+            "http://schema.org/itemListElement": [
+              {
+                "@list": [
+                  {
+                    "http://schema.org/name": [
+                      {
+                        "@language": "en",
+                        "@value": "Not difficult at all"
+                      }
+                    ],
+                    "http://schema.org/value": [
+                      {
+                        "@value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "http://schema.org/name": [
+                      {
+                        "@language": "en",
+                        "@value": "Somewhat difficult"
+                      }
+                    ],
+                    "http://schema.org/value": [
+                      {
+                        "@value": 1
+                      }
+                    ]
+                  },
+                  {
+                    "http://schema.org/name": [
+                      {
+                        "@language": "en",
+                        "@value": "Very difficult"
+                      }
+                    ],
+                    "http://schema.org/value": [
+                      {
+                        "@value": 2
+                      }
+                    ]
+                  },
+                  {
+                    "http://schema.org/name": [
+                      {
+                        "@language": "en",
+                        "@value": "Extremely difficult"
+                      }
+                    ],
+                    "http://schema.org/value": [
+                      {
+                        "@value": 3
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "http://schema.repronim.org/multipleChoice": [
+              {
+                "@type": "http://schema.org/Boolean",
+                "@value": false
+              }
+            ],
+            "http://schema.repronim.org/requiredValue": [
+              {
+                "@type": "http://schema.org/Boolean",
+                "@value": false
+              }
+            ],
+            "http://schema.org/maxValue": [
+              {
+                "@value": 3
+              }
+            ],
+            "http://schema.org/minValue": [
+              {
+                "@value": 0
+              }
+            ]
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "schema for Q10 of the PHQ-9 Assessment"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "phq9_10"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "Q10 of PHQ-9 Questionnaire"
+          }
+        ],
+        "https://schema.repronim.org/inputType": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#string",
+            "@value": "radio"
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/items/phq9a_1.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/items/phq9a_1",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Field.jsonld"
+        ],
+        "http://schema.org/question": [
+          {
+            "@language": "en",
+            "@value": "Little interest or pleasure in doing things"
+          }
+        ],
+        "https://schema.repronim.org/valueconstraints": [
+          {
+            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/valueConstraints.jsonld"
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "Q1 of the derived PHQ-9 Assessment"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "phq9a_1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "Q1 of PHQ-9a Questionnaire"
+          }
+        ],
+        "https://schema.repronim.org/inputType": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#string",
+            "@value": "radio"
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/items/phq9a_2.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/items/phq9a_2",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Field.jsonld"
+        ],
+        "http://schema.org/question": [
+          {
+            "@language": "en",
+            "@value": "Feeling down, depressed or hopeless?"
+          }
+        ],
+        "https://schema.repronim.org/valueconstraints": [
+          {
+            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/valueConstraints.jsonld"
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "Q2 of the derived PHQ-9 Assessment"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "phq9a_2"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "Q2 of PHQ-9a Questionnaire"
+          }
+        ],
+        "https://schema.repronim.org/inputType": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#string",
+            "@value": "radio"
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/items/phq9a_3.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/items/phq9a_3",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Field.jsonld"
+        ],
+        "http://schema.org/question": [
+          {
+            "@language": "en",
+            "@value": "Trouble falling or staying asleep, or sleeping too much?"
+          }
+        ],
+        "https://schema.repronim.org/valueconstraints": [
+          {
+            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/valueConstraints.jsonld"
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "Q3 of the derived PHQ-9 Assessment"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "phq9a_3"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "Q3 of PHQ-9a Questionnaire"
+          }
+        ],
+        "https://schema.repronim.org/inputType": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#string",
+            "@value": "radio"
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/items/phq9a_4.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/items/phq9a_4",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Field.jsonld"
+        ],
+        "http://schema.org/question": [
+          {
+            "@language": "en",
+            "@value": "Feeling tired or having little energy?"
+          }
+        ],
+        "https://schema.repronim.org/valueconstraints": [
+          {
+            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/valueConstraints.jsonld"
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "Q4 of the derived PHQ-9 Assessment"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "phq9a_4"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "Q4 of PHQ-9a Questionnaire"
+          }
+        ],
+        "https://schema.repronim.org/inputType": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#string",
+            "@value": "radio"
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/items/phq9a_5.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/items/phq9a_5",
+        "http://schema.org/question": [
+          {
+            "@language": "en",
+            "@value": "Poor appetite or overeating?"
+          }
+        ],
+        "https://schema.repronim.org/valueconstraints": [
+          {
+            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/valueConstraints.jsonld"
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "schema for Q5 of the derived PHQ-9 Assessment"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "phq9a_5"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "Q5 of PHQ-9a Questionnaire"
+          }
+        ],
+        "https://schema.repronim.org/inputType": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#string",
+            "@value": "radio"
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/items/phq9a_6.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/items/phq9a_6",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Field.jsonld"
+        ],
+        "http://schema.org/question": [
+          {
+            "@language": "en",
+            "@value": "Feeling bad about yourself \\u2014 or that you are a failure or have let yourself or your family down?"
+          }
+        ],
+        "https://schema.repronim.org/valueconstraints": [
+          {
+            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/valueConstraints.jsonld"
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "schema for Q6 of the derived PHQ-9 Assessment"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "phq9a_6"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "Q6 of PHQ-9a Questionnaire"
+          }
+        ],
+        "https://schema.repronim.org/inputType": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#string",
+            "@value": "radio"
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/items/phq9a_7.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/items/phq9a_7",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Field.jsonld"
+        ],
+        "http://schema.org/question": [
+          {
+            "@language": "en",
+            "@value": "Trouble concentrating on things, such as reading the newspaper or watching television?"
+          }
+        ],
+        "https://schema.repronim.org/valueconstraints": [
+          {
+            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/valueConstraints.jsonld"
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "schema for Q7 of the derived PHQ-9 Assessment"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "phq9a_7"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "Q7 of PHQ-9a Questionnaire"
+          }
+        ],
+        "https://schema.repronim.org/inputType": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#string",
+            "@value": "radio"
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/items/phq9a_8.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/items/phq9a_8",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Field.jsonld"
+        ],
+        "http://schema.org/question": [
+          {
+            "@language": "en",
+            "@value": "Moving or speaking so slowly that other people could have noticed? Or the opposite \\u2014 being so fidgety or restless that you have been moving around a lot more than usual?"
+          }
+        ],
+        "https://schema.repronim.org/valueconstraints": [
+          {
+            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/valueConstraints.jsonld"
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@value": "schema for Q8 of the derived PHQ-9 Assessment",
+            "@language": "en"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "phq9a_8"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "Q8 of PHQ-9a Questionnaire"
+          }
+        ],
+        "https://schema.repronim.org/inputType": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#string",
+            "@value": "radio"
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/items/phq9a_9.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/items/phq9a_9",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Field.jsonld"
+        ],
+        "http://schema.org/question": [
+          {
+            "@language": "en",
+            "@value": "Thoughts that you would be better off dead or of hurting yourself in some way?"
+          }
+        ],
+        "https://schema.repronim.org/valueconstraints": [
+          {
+            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/valueConstraints.jsonld"
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "schema for Q9 of the derived PHQ-9 Assessment"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "phq9a_9"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "Q9 of PHQ-9a Questionnaire"
+          }
+        ],
+        "https://schema.repronim.org/inputType": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#string",
+            "@value": "radio"
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/items/phq9a_10.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/items/phq9_10",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Field.jsonld"
+        ],
+        "http://schema.org/question": [
+          {
+            "@language": "en",
+            "@value": "If you checked off any problems, how difficult have these problems made it for you to do your work, take care of things at home, or get along with other people?"
+          }
+        ],
+        "https://schema.repronim.org/valueconstraints": [
+          {
+            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/valueConstraints.jsonld"
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "schema for Q10 of the derived PHQ-9 Assessment"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "phq9a_10"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "Q10 of PHQ-9a Questionnaire"
+          }
+        ],
+        "https://schema.repronim.org/inputType": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#string",
+            "@value": "radio"
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-8/items/phq8_1.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-8/items/phq8_1",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Field.jsonld"
+        ],
+        "http://schema.org/question": [
+          {
+            "@language": "en",
+            "@value": "Little interest or pleasure in doing things"
+          }
+        ],
+        "https://schema.repronim.org/valueconstraints": [
+          {
+            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-8/valueConstraints.jsonld"
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "Q1 of the PHQ-8 Assessment"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "phq8_1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "PHQ-8 Questionnaire"
+          }
+        ],
+        "https://schema.repronim.org/inputType": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#string",
+            "@value": "radio"
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-8/items/phq8_2.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-8/items/phq8_1",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Field.jsonld"
+        ],
+        "http://schema.org/question": [
+          {
+            "@language": "en",
+            "@value": "Feeling down, depressed or hopeless?"
+          }
+        ],
+        "https://schema.repronim.org/valueconstraints": [
+          {
+            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-8/valueConstraints.jsonld"
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "Q2 of PHQ-8 Assessment"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "phq8_2"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "PHQ-8 Questionnaire"
+          }
+        ],
+        "https://schema.repronim.org/inputType": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#string",
+            "@value": "radio"
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-8/items/phq8_3.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-8/items/phq8_3",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Field.jsonld"
+        ],
+        "http://schema.org/question": [
+          {
+            "@language": "en",
+            "@value": "Trouble falling or staying asleep, or sleeping too much?"
+          }
+        ],
+        "https://schema.repronim.org/valueconstraints": [
+          {
+            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-8/valueConstraints.jsonld"
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "Q3 of PHQ-8 Assessment"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "phq8_3"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "PHQ-8 Questionnaire"
+          }
+        ],
+        "https://schema.repronim.org/inputType": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#string",
+            "@value": "radio"
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-8/items/phq8_4.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-8/items/phq8_4",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Field.jsonld"
+        ],
+        "http://schema.org/question": [
+          {
+            "@language": "en",
+            "@value": "Feeling tired or having little energy?"
+          }
+        ],
+        "https://schema.repronim.org/valueconstraints": [
+          {
+            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-8/valueConstraints.jsonld"
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "Q4 of PHQ-8 Assessment"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "phq8_4"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "PHQ-8 Questionnaire"
+          }
+        ],
+        "https://schema.repronim.org/inputType": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#string",
+            "@value": "radio"
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-8/items/phq8_5.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-8/items/phq8_5",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Field.jsonld"
+        ],
+        "http://schema.org/question": [
+          {
+            "@language": "en",
+            "@value": "Poor appetite or overeating?"
+          }
+        ],
+        "https://schema.repronim.org/valueconstraints": [
+          {
+            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-8/valueConstraints.jsonld"
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "PHQ-8 Assessment"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "phq8_5"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "PHQ-8 Questionnaire"
+          }
+        ],
+        "https://schema.repronim.org/inputType": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#string",
+            "@value": "radio"
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-8/items/phq8_6.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-8/items/phq8_6",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Field.jsonld"
+        ],
+        "http://schema.org/question": [
+          {
+            "@language": "en",
+            "@value": "Feeling bad about yourself \\u2014 or that you are a failure or have let yourself or your family down?"
+          }
+        ],
+        "https://schema.repronim.org/valueconstraints": [
+          {
+            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-8/valueConstraints.jsonld"
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "Q6 of PHQ-8 Assessment"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "phq8_6"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "Q6 PHQ-8"
+          }
+        ],
+        "https://schema.repronim.org/inputType": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#string",
+            "@value": "radio"
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-8/items/phq8_7.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-8/items/phq8_7",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Field.jsonld"
+        ],
+        "http://schema.org/question": [
+          {
+            "@language": "en",
+            "@value": "Trouble concentrating on things, such as reading the newspaper or watching television? ENG"
+          }
+        ],
+        "https://schema.repronim.org/valueconstraints": [
+          {
+            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-8/valueConstraints.jsonld"
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "Q7 of PHQ-8 Assessment"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "phq8_7"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "Q7 PHQ-8"
+          }
+        ],
+        "https://schema.repronim.org/inputType": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#string",
+            "@value": "radio"
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-8/items/phq8_8.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-8/items/phq8_8",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Field.jsonld"
+        ],
+        "http://schema.org/question": [
+          {
+            "@language": "en",
+            "@value": "Moving or speaking so slowly that other people could have noticed? Or the opposite \\u2014 being so fidgety or restless that you have been moving around a lot more than usual?"
+          }
+        ],
+        "https://schema.repronim.org/valueconstraints": [
+          {
+            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-8/valueConstraints.jsonld"
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "Q8 of the PHQ-8 Assessment"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "phq8_8"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "Q8 PHQ-8"
+          }
+        ],
+        "https://schema.repronim.org/inputType": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#string",
+            "@value": "radio"
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/voice_task/items/say_ah.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/voice_task/items/say_ah",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Field.jsonld"
+        ],
+        "http://schema.org/question": [
+          {
+            "@language": "en",
+            "@value": "Say 'ahhh' for 10 seconds"
+          }
+        ],
+        "https://schema.repronim.org/valueconstraints": [
+          {
+            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/voice_task/items/say_ah_valueConstraints.jsonld"
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "say ah for 10 seconds"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "say_ah"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "Say Ah"
+          }
+        ],
+        "https://schema.repronim.org/inputType": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#string",
+            "@value": "audioRecord"
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/voice_task/items/pataka.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/voice_task/items/pataka",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Field.jsonld"
+        ],
+        "http://schema.org/question": [
+          {
+            "@language": "en",
+            "@value": "Say 'pataka' as fast as you can for a minute"
+          }
+        ],
+        "https://schema.repronim.org/valueconstraints": [
+          {
+            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/voice_task/items/pataka_valueConstraints.jsonld"
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "pataka task"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "pataka"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "Say pataka"
+          }
+        ],
+        "https://schema.repronim.org/inputType": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#string",
+            "@value": "audioRecord"
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/voice_task/items/guided_speech.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/voice_task/items/guided_speech",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Field.jsonld"
+        ],
+        "http://schema.org/question": [
+          {
+            "@language": "en",
+            "@value": "Look at the map in the image below, and give directions in 1 min to another person over the phone as to how you would go from Start to End."
+          }
+        ],
+        "https://schema.repronim.org/valueconstraints": [
+          {
+            "http://schema.repronim.org/multipleChoice": [
+              {
+                "@type": "http://schema.org/Boolean",
+                "@value": false
+              }
+            ],
+            "http://schema.repronim.org/requiredValue": [
+              {
+                "@type": "http://schema.org/Boolean",
+                "@value": true
+              }
+            ],
+            "http://schema.org/image": [
+              {
+                "@language": "en",
+                "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/voice_task/map.png"
+              }
+            ],
+            "http://schema.org/maxValue": [
+              {
+                "@value": 60000
+              }
+            ],
+            "http://schema.org/minValue": [
+              {
+                "@value": 0
+              }
+            ]
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "guided speech item for voice task"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "guided speech"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "Guided speech"
+          }
+        ],
+        "https://schema.repronim.org/inputType": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#string",
+            "@value": "audioImageRecord"
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/voice_task/items/free_speech.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/voice_task/items/free_speech",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Field.jsonld"
+        ],
+        "http://schema.org/question": [
+          {
+            "@language": "en",
+            "@value": "In 1 min please state the name of the last movie or television show that you were really \"struck by\". Describe three things that made it memorable."
+          }
+        ],
+        "https://schema.repronim.org/valueconstraints": [
+          {
+            "http://schema.repronim.org/multipleChoice": [
+              {
+                "@type": "http://schema.org/Boolean",
+                "@value": false
+              }
+            ],
+            "http://schema.repronim.org/requiredValue": [
+              {
+                "@type": "http://schema.org/Boolean",
+                "@value": true
+              }
+            ],
+            "http://schema.org/maxValue": [
+              {
+                "@value": 60000
+              }
+            ],
+            "http://schema.org/minValue": [
+              {
+                "@value": 0
+              }
+            ]
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "free speech item for voice task"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "free speech"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "Free speech"
+          }
+        ],
+        "https://schema.repronim.org/inputType": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#string",
+            "@value": "audioRecord"
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/voice_task/items/describe_image.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/voice_task/items/phq8_1",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Field.jsonld"
+        ],
+        "http://schema.org/question": [
+          {
+            "@language": "en",
+            "@value": "Describe the image shown below for a minute"
+          }
+        ],
+        "https://schema.repronim.org/valueconstraints": [
+          {
+            "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/voice_task/items/describe_image_valueConstraints.jsonld"
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "say ah for 10 seconds"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "pataka"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "Say pataka"
+          }
+        ],
+        "https://schema.repronim.org/inputType": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#string",
+            "@value": "audioImageRecord"
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/voice_task/multipart_voice_schema.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/voice_task/phq8_schema",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Activity.jsonld"
+        ],
+        "https://schema.repronim.org/branchLogic": [],
+        "http://schema.repronim.org/preamble": [
+          {
+            "@language": "en",
+            "@value": "Please record your voice while doing the following:"
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "Voice tasks"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "https://schema.repronim.org/scoringLogic": [],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "voice tasks"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "voice tasks"
+          }
+        ],
+        "https://schema.repronim.org/allow": [
+          {
+            "@list": [
+              {
+                "@id": "https://schema.repronim.org/refused_to_answer"
+              },
+              {
+                "@id": "https://schema.repronim.org/dont_know_answer"
+              }
+            ]
+          }
+        ],
+        "https://schema.repronim.org/inputType": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#string",
+            "@value": "multipart"
+          }
+        ],
+        "https://schema.repronim.org/order": [
+          {
+            "@list": [
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/voice_task/items/view_numbers.jsonld"
+              },
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/voice_task/items/read_passage.jsonld"
+              },
+              {
+                "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/voice_task/items/say_numbers.jsonld"
+              }
+            ]
+          }
+        ],
+        "https://schema.repronim.org/shuffle": [
+          {
+            "@type": "http://schema.org/Boolean",
+            "@value": false
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/voice_task/items/phonetic.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/voice_task/items/phonetic_p",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Field.jsonld"
+        ],
+        "http://schema.repronim.org/preamble": [
+          {
+            "@language": "en",
+            "@value": "Read the passage below out loud while recording yourself."
+          }
+        ],
+        "http://schema.org/question": [
+          {
+            "@language": "en",
+            "@value": "Some time ago, in a place neither near nor far, there lived a king who didn\\u2019t know how to count, not even to zero.  Some say this is the reason he would always wish for more \\u2014 more food, more gold, more land. He simply didn\\u2019t realize how much he already owned.  Everyone in his kingdom could do the math and tally bushels of corn, loaves of bread, and urns of gold. But how would they measure the height of his castle or the stretch of his kingdom?  You might think \\u201cAaah, ooh, easy \\u2014 just measure it in meters!\\u201d But in those days, the useless unit of measure was based on stains splattered along the king\\u2019s cloak while drinking shrub juice.  The kingdom needed a new way of counting distance. \\u201cA kingdom without a proper ruler,\\u201d proclaimed the king, \\u201cis like riches without measure.\\u201d He launched a challenge amid trumpets, drums, flags and cannons.  \\u201cThe person who creates a unit of measure fit for a ruler will be rewarded beyond measure!\\u201d A tall order indeed! The first person to come forward was a bulky locksmith with a stiff jaw. He approached the king with an air of secrecy and whispered, \\u201cI have the key to measure the kingdom, but only I can wield it.\\u201d  He then rubbed his beard and pulled the key from his locks of oily hair. The key turned out to be a hair itself! \\u201cJudge the reach of my vast kingdom with a hair\\u2019s width?\\u201d laughed the king. \\u201cWhat a poor idea. That would take forever or longer!\\u201d The second person eager for the prize was a fidgety boy who knew all numbers (including zero).  He produced a curious object from one of his many pockets. It was a complex shape that seemed to change proportions depending on which direction you gazed upon it. The boy said in a measured voice, \\u201cThis polyhedron has many edges, with each edge of a different length. Only a king could be counted on to use it justly.\\u201d He gave the king an awful earful of an explanation that went on and on.  The long and the short of it was that the king could make no more use of it than of a puddle of spilled oatmeal. Finally, a little girl with a big idea tugged on the mismeasured cloak of the king. The king sized up the little girl with the big idea and said \\u201cI don\\u2019t have time for this, and for that matter, I have no concept of space, either.\\u201d The girl looked up, then down, then spun around and blurted out: \\u201cAren\\u2019t you able to solve the puzzle yourself?  Why must you break up your kingdom into tiny pieces when everything around you is Humpty Dumpty together again? Your kingdom IS a unit and you are the ruler.\\u201d The king \\u2014 startled, befuddled, and bemused \\u2014 found the words wise. He aimed to be satisfied with all around him, big or small or somewhere in between."
+          }
+        ],
+        "https://schema.repronim.org/valueconstraints": [
+          {
+            "http://schema.repronim.org/requiredValue": [
+              {
+                "@type": "http://schema.org/Boolean",
+                "@value": true
+              }
+            ],
+            "http://schema.org/maxValue": [
+              {
+                "@value": 60000
+              }
+            ],
+            "http://schema.org/minValue": [
+              {
+                "@value": 0
+              }
+            ]
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "phonetic passage task"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "phonetic"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "phonetic_passage"
+          }
+        ],
+        "https://schema.repronim.org/inputType": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#string",
+            "@value": "audioPassageRecord"
+          }
+        ]
+      }
+    ],
+    "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/voice_task/items/rainbow_passage.jsonld": [
+      {
+        "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/voice_task/items/rainbow_p",
+        "@type": [
+          "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/Field.jsonld"
+        ],
+        "http://schema.repronim.org/preamble": [
+          {
+            "@language": "en",
+            "@value": "Read the passage below out loud while recording yourself."
+          }
+        ],
+        "http://schema.org/question": [
+          {
+            "@language": "en",
+            "@value": "When the sunlight strikes raindrops in the air, they act as a prism and form a rainbow. The rainbow is a division of white light into many beautiful colors. These take the shape of a long round arch, with its path high above, and its two ends apparently beyond the horizon. There is , according to legend, a boiling pot of gold at one end. People look, but no one ever finds it. When a man looks for something beyond his reach, his friends say he is looking for the pot of gold at the end of the rainbow. Throughout the centuries people have explained the rainbow in various ways. Some have accepted it as a miracle without physical explanation. To the Hebrews it was a token that there would be no more universal floods. The Greeks used to imagine that it was a sign from the gods to foretell war or heavy rain. The Norsemen considered the rainbow as a bridge over which the gods passed from earth to their home in the sky. Others have tried to explain the phenomenon physically. Aristotle thought that the rainbow was caused by reflection of the sun's rays by the rain. Since then physicists have found that it is not reflection, but refraction by the raindrops which causes the rainbows. Many complicated ideas about the rainbow have been formed. The difference in the rainbow depends considerably upon the size of the drops, and the width of the colored band increases as the size of the drops increases. The actual primary rainbow observed is said to be the effect of super-imposition of a number of bows. If the red of the second bow falls upon the green of the first, the result is to give a bow with an abnormally wide yellow band, since red and green light when mixed form yellow. This is a very common type of bow, one showing mainly red and yellow, with little or no green or blue."
+          }
+        ],
+        "https://schema.repronim.org/valueconstraints": [
+          {
+            "http://schema.repronim.org/requiredValue": [
+              {
+                "@type": "http://schema.org/Boolean",
+                "@value": true
+              }
+            ],
+            "http://schema.org/maxValue": [
+              {
+                "@value": 60000
+              }
+            ],
+            "http://schema.org/minValue": [
+              {
+                "@value": 0
+              }
+            ]
+          }
+        ],
+        "http://schema.org/description": [
+          {
+            "@language": "en",
+            "@value": "rainbow task"
+          }
+        ],
+        "http://schema.org/schemaVersion": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://schema.org/version": [
+          {
+            "@language": "en",
+            "@value": "0.0.1"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#altLabel": [
+          {
+            "@language": "en",
+            "@value": "pataka"
+          }
+        ],
+        "http://www.w3.org/2004/02/skos/core#prefLabel": [
+          {
+            "@language": "en",
+            "@value": "rainbow_passage"
+          }
+        ],
+        "https://schema.repronim.org/inputType": [
+          {
+            "@type": "http://www.w3.org/2001/XMLSchema#string",
+            "@value": "audioPassageRecord"
+          }
+        ]
+      }
+    ]
+  },
+  "applet": [
+    {
+      "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activity-sets/example/nda_phq_schema",
+      "@type": [
+        "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/schemas/ActivitySet.jsonld"
+      ],
+      "http://schema.org/description": [
+        {
+          "@language": "en",
+          "@value": "activity set for NDA-PHQ Assessments"
+        }
+      ],
+      "http://schema.org/schemaVersion": [
+        {
+          "@language": "en",
+          "@value": "0.0.1"
+        }
+      ],
+      "http://schema.org/version": [
+        {
+          "@language": "en",
+          "@value": "0.0.1"
+        }
+      ],
+      "http://www.w3.org/2004/02/skos/core#altLabel": [
+        {
+          "@language": "en",
+          "@value": "nda_phq"
+        }
+      ],
+      "http://www.w3.org/2004/02/skos/core#prefLabel": [
+        {
+          "@language": "en",
+          "@value": "NDA PHQ Assessment"
+        }
+      ],
+      "https://schema.repronim.org/order": [
+        {
+          "@list": [
+            {
+              "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/nda_guid.jsonld"
+            },
+            {
+              "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/phq9_schema.jsonld"
+            },
+            {
+              "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/phq9a_schema.jsonld"
+            },
+            {
+              "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-8/phq8_schema.jsonld"
+            },
+            {
+              "@id": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/voice_task/voice_task_schema.jsonld"
+            }
+          ]
+        }
+      ],
+      "https://schema.repronim.org/shuffle": [
+        {
+          "@type": "http://schema.org/Boolean",
+          "@value": false
+        }
+      ]
+    }
+  ]
+}

--- a/app/models/json-ld.js
+++ b/app/models/json-ld.js
@@ -1,0 +1,84 @@
+const DESCRIPTION = 'http://schema.org/description';
+const SCHEMA_VERSION = 'http://schema.org/schemaVersion';
+const VERSION = 'http://schema.org/version';
+const ALT_LABEL = 'http://www.w3.org/2004/02/skos/core#altLabel';
+const PREF_LABEL = 'http://www.w3.org/2004/02/skos/core#prefLabel';
+const ORDER = 'https://schema.repronim.org/order';
+const SHUFFLE = 'https://schema.repronim.org/shuffle';
+const VISIBILITY = 'https://schema.repronim.org/visibility';
+const PREAMBLE = 'http://schema.repronim.org/preamble';
+const SCORING_LOGIC = 'https://schema.repronim.org/scoringLogic';
+const REFUSE_TO_ANSWER = 'https://schema.repronim.org/refused_to_answer';
+const DO_NOT_KNOW = 'https://schema.repronim.org/dont_know_answer';
+const ALLOW = 'https://schema.repronim.org/allow';
+const IMAGE = 'http://schema.org/image';
+
+export const languageListToObject = (list = []) => list.reduce((obj, item) => ({
+  ...obj,
+  [item['@language']]: item['@value'],
+}), {});
+
+export const listToObject = (list = []) => list.reduce((obj, item) => ({
+  ...obj,
+  [item['@index']]: item['@value'],
+}), {});
+
+export const flattenIdList = (list = []) => list.map(item => item['@id']);
+
+export const appletTransformJson = (appletJson) => {
+  const name = languageListToObject(appletJson[PREF_LABEL]);
+  const description = languageListToObject(appletJson[DESCRIPTION]);
+  const schemaVersion = languageListToObject(appletJson[SCHEMA_VERSION]);
+  const version = languageListToObject(appletJson[VERSION]);
+  const altLabel = languageListToObject(appletJson[ALT_LABEL]);
+  const visibility = listToObject(appletJson[VISIBILITY]);
+  const order = flattenIdList(appletJson[ORDER][0]['@list']);
+  return {
+    name: name.en,
+    description: description.en,
+    altLabel: altLabel.en,
+    schemaVersion: schemaVersion.en,
+    version: version.en,
+    shuffle: appletJson[SHUFFLE][0]['@value'],
+    visibility,
+    order,
+  };
+};
+
+export const activityTransformJson = (activityJson) => {
+  const name = languageListToObject(activityJson[PREF_LABEL]);
+  const description = languageListToObject(activityJson[DESCRIPTION]);
+  const schemaVersion = languageListToObject(activityJson[SCHEMA_VERSION]);
+  const version = languageListToObject(activityJson[VERSION]);
+  const preamble = languageListToObject(activityJson[PREAMBLE]);
+  const altLabel = languageListToObject(activityJson[ALT_LABEL]);
+  const visibility = listToObject(activityJson[VISIBILITY]);
+  const order = flattenIdList(activityJson[ORDER][0]['@list']);
+
+  const allowList = activityJson[ALLOW] ? flattenIdList(activityJson[ALLOW][0]['@list']) : [];
+  const allowRefuseToAnswer = allowList.includes(REFUSE_TO_ANSWER);
+  const allowDoNotKnow = allowList.includes(DO_NOT_KNOW);
+
+  const scoringLogic = activityJson[SCORING_LOGIC]; // TO DO
+  const image = activityJson[IMAGE]; // TO DO
+  const notification = {}; // TO DO
+  const info = languageListToObject(activityJson.info); // TO DO
+
+  return {
+    name: name.en,
+    description: description.en,
+    altLabel: altLabel.en,
+    schemaVersion: schemaVersion.en,
+    version: version.en,
+    preamble: preamble.en,
+    image,
+    shuffle: activityJson[SHUFFLE][0]['@value'],
+    scoringLogic,
+    visibility,
+    order,
+    allowRefuseToAnswer,
+    allowDoNotKnow,
+    notification,
+    info: info.en,
+  };
+};

--- a/app/models/json-ld.js
+++ b/app/models/json-ld.js
@@ -1,84 +1,131 @@
-const DESCRIPTION = 'http://schema.org/description';
-const SCHEMA_VERSION = 'http://schema.org/schemaVersion';
-const VERSION = 'http://schema.org/version';
-const ALT_LABEL = 'http://www.w3.org/2004/02/skos/core#altLabel';
-const PREF_LABEL = 'http://www.w3.org/2004/02/skos/core#prefLabel';
-const ORDER = 'https://schema.repronim.org/order';
-const SHUFFLE = 'https://schema.repronim.org/shuffle';
-const VISIBILITY = 'https://schema.repronim.org/visibility';
-const PREAMBLE = 'http://schema.repronim.org/preamble';
-const SCORING_LOGIC = 'https://schema.repronim.org/scoringLogic';
-const REFUSE_TO_ANSWER = 'https://schema.repronim.org/refused_to_answer';
-const DO_NOT_KNOW = 'https://schema.repronim.org/dont_know_answer';
-const ALLOW = 'https://schema.repronim.org/allow';
-const IMAGE = 'http://schema.org/image';
+import * as R from 'ramda';
 
-export const languageListToObject = (list = []) => list.reduce((obj, item) => ({
-  ...obj,
-  [item['@language']]: item['@value'],
-}), {});
+const ALLOW = 'https://schema.repronim.org/allow';
+const ALT_LABEL = 'http://www.w3.org/2004/02/skos/core#altLabel';
+const DESCRIPTION = 'http://schema.org/description';
+const DO_NOT_KNOW = 'https://schema.repronim.org/dont_know_answer';
+const IMAGE = 'http://schema.org/image';
+const INPUT_TYPE = 'https://schema.repronim.org/inputType';
+const ITEM_LIST_ELEMENT = 'http://schema.org/itemListElement';
+const MAX_VALUE = 'http://schema.org/maxValue';
+const MIN_VALUE = 'http://schema.org/minValue';
+const MULTIPLE_CHOICE = 'http://schema.repronim.org/multipleChoice';
+const NAME = 'http://schema.org/name';
+const ORDER = 'https://schema.repronim.org/order';
+const PREAMBLE = 'http://schema.repronim.org/preamble';
+const PREF_LABEL = 'http://www.w3.org/2004/02/skos/core#prefLabel';
+const QUESTION = 'http://schema.org/question';
+const REFUSE_TO_ANSWER = 'https://schema.repronim.org/refused_to_answer';
+const REQUIRED_VALUE = 'http://schema.repronim.org/requiredValue';
+const SCHEMA_VERSION = 'http://schema.org/schemaVersion';
+const SCORING_LOGIC = 'https://schema.repronim.org/scoringLogic';
+const SHUFFLE = 'https://schema.repronim.org/shuffle';
+const VALUE = 'http://schema.org/value';
+const VALUE_CONSTRAINTS = 'https://schema.repronim.org/valueconstraints';
+const VERSION = 'http://schema.org/version';
+const VISIBILITY = 'https://schema.repronim.org/visibility';
+
+export const languageListToObject = (list) => {
+  if (typeof list === 'undefined' || list.length === 0) {
+    return undefined;
+  }
+  return list.reduce((obj, item) => ({
+    ...obj,
+    [item['@language']]: item['@value'],
+  }), {});
+};
 
 export const listToObject = (list = []) => list.reduce((obj, item) => ({
   ...obj,
   [item['@index']]: item['@value'],
 }), {});
 
+export const listToValue = (list = []) => (list.length > 0
+  ? list[0]['@value']
+  : undefined);
+
 export const flattenIdList = (list = []) => list.map(item => item['@id']);
 
-export const appletTransformJson = (appletJson) => {
-  const name = languageListToObject(appletJson[PREF_LABEL]);
-  const description = languageListToObject(appletJson[DESCRIPTION]);
-  const schemaVersion = languageListToObject(appletJson[SCHEMA_VERSION]);
-  const version = languageListToObject(appletJson[VERSION]);
-  const altLabel = languageListToObject(appletJson[ALT_LABEL]);
-  const visibility = listToObject(appletJson[VISIBILITY]);
-  const order = flattenIdList(appletJson[ORDER][0]['@list']);
-  return {
-    name: name.en,
-    description: description.en,
-    altLabel: altLabel.en,
-    schemaVersion: schemaVersion.en,
-    version: version.en,
-    shuffle: appletJson[SHUFFLE][0]['@value'],
-    visibility,
-    order,
-  };
-};
+export const flattenItemList = (list = []) => list.map(item => ({
+  name: languageListToObject(item[NAME]),
+  value: R.path([VALUE, 0, '@value'], item),
+  image: languageListToObject(item[IMAGE]),
+}));
+
+export const flattenValueConstraints = vcObj => Object.keys(vcObj).reduce((accumulator, key) => {
+  if (key === MAX_VALUE) {
+    return { ...accumulator, maxValue: R.path([key, 0, '@value'], vcObj) };
+  }
+  if (key === MIN_VALUE) {
+    return { ...accumulator, minValue: R.path([key, 0, '@value'], vcObj) };
+  }
+  if (key === MULTIPLE_CHOICE) {
+    return { ...accumulator, multipleChoice: R.path([key, 0, '@value'], vcObj) };
+  }
+  if (key === ITEM_LIST_ELEMENT) {
+    const itemList = R.path([key, 0, '@list'], vcObj);
+    return { ...accumulator, itemList: flattenItemList(itemList) };
+  }
+  if (key === REQUIRED_VALUE) {
+    return { ...accumulator, required: R.path([key, 0, '@value'], vcObj) };
+  }
+  if (key === IMAGE) {
+    return { ...accumulator, image: languageListToObject(vcObj[key]) };
+  }
+}, {});
+
+export const appletTransformJson = appletJson => ({
+  name: languageListToObject(appletJson[PREF_LABEL]),
+  description: languageListToObject(appletJson[DESCRIPTION]),
+  schemaVersion: languageListToObject(appletJson[SCHEMA_VERSION]),
+  version: languageListToObject(appletJson[VERSION]),
+  altLabel: languageListToObject(appletJson[ALT_LABEL]),
+  visibility: listToObject(appletJson[VISIBILITY]),
+  order: flattenIdList(appletJson[ORDER][0]['@list']),
+  shuffle: R.path([SHUFFLE, 0, '@value'], appletJson),
+});
 
 export const activityTransformJson = (activityJson) => {
-  const name = languageListToObject(activityJson[PREF_LABEL]);
-  const description = languageListToObject(activityJson[DESCRIPTION]);
-  const schemaVersion = languageListToObject(activityJson[SCHEMA_VERSION]);
-  const version = languageListToObject(activityJson[VERSION]);
-  const preamble = languageListToObject(activityJson[PREAMBLE]);
-  const altLabel = languageListToObject(activityJson[ALT_LABEL]);
-  const visibility = listToObject(activityJson[VISIBILITY]);
-  const order = flattenIdList(activityJson[ORDER][0]['@list']);
-
-  const allowList = activityJson[ALLOW] ? flattenIdList(activityJson[ALLOW][0]['@list']) : [];
+  const allowList = flattenIdList(R.pathOr([], [ALLOW, 0, '@list'], activityJson));
   const allowRefuseToAnswer = allowList.includes(REFUSE_TO_ANSWER);
   const allowDoNotKnow = allowList.includes(DO_NOT_KNOW);
 
   const scoringLogic = activityJson[SCORING_LOGIC]; // TO DO
-  const image = activityJson[IMAGE]; // TO DO
   const notification = {}; // TO DO
   const info = languageListToObject(activityJson.info); // TO DO
 
   return {
-    name: name.en,
-    description: description.en,
-    altLabel: altLabel.en,
-    schemaVersion: schemaVersion.en,
-    version: version.en,
-    preamble: preamble.en,
-    image,
-    shuffle: activityJson[SHUFFLE][0]['@value'],
-    scoringLogic,
-    visibility,
-    order,
+    name: languageListToObject(activityJson[PREF_LABEL]),
+    description: languageListToObject(activityJson[DESCRIPTION]),
+    schemaVersion: languageListToObject(activityJson[SCHEMA_VERSION]),
+    version: languageListToObject(activityJson[VERSION]),
+    preamble: languageListToObject(activityJson[PREAMBLE]),
+    altLabel: languageListToObject(activityJson[ALT_LABEL]),
+    visibility: listToObject(activityJson[VISIBILITY]),
+    order: flattenIdList(activityJson[ORDER][0]['@list']),
+    shuffle: R.path([SHUFFLE, 0, '@value'], activityJson),
+    image: languageListToObject(activityJson[IMAGE]),
     allowRefuseToAnswer,
     allowDoNotKnow,
+    scoringLogic,
     notification,
-    info: info.en,
+    info,
+  };
+};
+
+export const itemTransformJson = (itemJson) => {
+  const valueConstraintsObj = R.pathOr({}, [VALUE_CONSTRAINTS, 0], itemJson);
+  const valueConstraints = flattenValueConstraints(valueConstraintsObj);
+
+  return {
+    name: languageListToObject(itemJson[PREF_LABEL]),
+    description: languageListToObject(itemJson[DESCRIPTION]),
+    schemaVersion: languageListToObject(itemJson[SCHEMA_VERSION]),
+    version: languageListToObject(itemJson[VERSION]),
+    altLabel: languageListToObject(itemJson[ALT_LABEL]),
+    inputType: listToValue(itemJson[INPUT_TYPE]),
+    question: languageListToObject(itemJson[QUESTION]),
+    preamble: languageListToObject(itemJson[PREAMBLE]),
+    valueConstraints,
   };
 };


### PR DESCRIPTION
Adds several helper functions for transforming JSON-LD schemas into easy-to-use javascript objects.

The MindLogger API will soon start serving up applets and activities in expanded JSON-LD format, following the structure found at https://github.com/ReproNim/schema-standardization.

This PR adds some helper functions for processing the JSON-LD schemas so that we can display the applets, activities, and screens in the app.

**To do:**
 - The structure of notifications, info pages, and Girder IDs has not been finalized yet
 - Activities will have a `variableMap` added to schemas to associate IRIs with short names
 - Complex item value constraints (e.g. for drawings, files, table inputs) were not handled
 - The only applets which were used for testing are https://github.com/ReproNim/schema-standardization/tree/master/activity-sets/ema-hbn and https://github.com/ReproNim/schema-standardization/tree/master/activity-sets/example. We'll need a wider variety of applets to ensure no properties are accidentally left out.