### PR TITLE
Audio Play and Record widgets

### DIFF
--- a/app/components/ActivityButtons.js
+++ b/app/components/ActivityButtons.js
@@ -11,30 +11,35 @@ const styles = StyleSheet.create({
   },
 });
 
+const renderButton = (label, enabled, onPress) => {
+  if (!enabled || !label) {
+    return (<ScreenButton transparent />);
+  }
+  return (<ScreenButton transparent onPress={onPress} text={label} />);
+};
+
 const ActivityButtons = ({
   nextLabel,
+  nextEnabled,
   prevLabel,
+  prevEnabled,
   actionLabel,
   onPressPrev,
   onPressNext,
   onPressAction,
 }) => (
   <View style={styles.footer}>
-    {prevLabel
-      ? <ScreenButton transparent onPress={onPressPrev} text={prevLabel} />
-      : <ScreenButton transparent />}
-    {actionLabel
-      ? <ScreenButton transparent onPress={onPressAction} text={actionLabel} />
-      : <ScreenButton transparent />}
-    {nextLabel !== 'Skip'
-      ? <ScreenButton onPress={onPressNext} text={nextLabel} />
-      : <ScreenButton transparent onPress={onPressNext} text={nextLabel} />}
+    {renderButton(prevLabel, prevEnabled, onPressPrev)}
+    {renderButton(actionLabel, true, onPressAction)}
+    {renderButton(nextLabel, nextEnabled, onPressNext)}
   </View>
 );
 
 ActivityButtons.defaultProps = {
   nextLabel: undefined,
+  nextEnabled: true,
   prevLabel: undefined,
+  prevEnabled: true,
   actionLabel: undefined,
   onPressPrev: undefined,
   onPressNext: undefined,
@@ -43,7 +48,9 @@ ActivityButtons.defaultProps = {
 
 ActivityButtons.propTypes = {
   nextLabel: PropTypes.string,
+  nextEnabled: PropTypes.bool,
   prevLabel: PropTypes.string,
+  prevEnabled: PropTypes.bool,
   actionLabel: PropTypes.string,
   onPressPrev: PropTypes.func,
   onPressNext: PropTypes.func,

--- a/app/components/screen/index.js
+++ b/app/components/screen/index.js
@@ -7,6 +7,7 @@ import WidgetError from './WidgetError';
 import {
   AudioImageRecord,
   AudioRecord,
+  AudioStimulus,
   DatePicker,
   MultiSelect,
   Radio,
@@ -140,6 +141,15 @@ class Screen extends Component {
           onChange={onChange}
           config={screen.valueConstraints}
           value={answer}
+        />
+      );
+    }
+    if (screen.inputType === 'audioStimulus') {
+      return (
+        <AudioStimulus
+          onChange={onChange}
+          config={screen.inputs}
+          isCurrent={isCurrent}
         />
       );
     }

--- a/app/components/screen/index.js
+++ b/app/components/screen/index.js
@@ -147,6 +147,7 @@ class Screen extends Component {
     if (screen.inputType === 'audioStimulus') {
       return (
         <AudioStimulus
+          value={answer}
           onChange={onChange}
           config={screen.inputs}
           isCurrent={isCurrent}

--- a/app/models/json-ld.js
+++ b/app/models/json-ld.js
@@ -2,6 +2,8 @@ import * as R from 'ramda';
 
 const ALLOW = 'https://schema.repronim.org/allow';
 const ALT_LABEL = 'http://www.w3.org/2004/02/skos/core#altLabel';
+const AUDIO_OBJECT = 'http://schema.org/AudioObject';
+const CONTENT_URL = 'http://schema.org/contentUrl';
 const DESCRIPTION = 'http://schema.org/description';
 const DO_NOT_KNOW = 'https://schema.repronim.org/dont_know_answer';
 const IMAGE = 'http://schema.org/image';
@@ -22,6 +24,7 @@ const REQUIRED_VALUE = 'http://schema.repronim.org/requiredValue';
 const SCHEMA_VERSION = 'http://schema.org/schemaVersion';
 const SCORING_LOGIC = 'https://schema.repronim.org/scoringLogic';
 const SHUFFLE = 'https://schema.repronim.org/shuffle';
+const TRANSCRIPT = 'http://schema.org/transcript';
 const URL = 'http://schema.org/url';
 const VALUE = 'http://schema.org/value';
 const VALUE_CONSTRAINTS = 'https://schema.repronim.org/valueconstraints';
@@ -90,6 +93,13 @@ export const transformInputs = inputs => inputs.reduce((accumulator, inputObj) =
   if (typeof val === 'undefined' && inputObj[ITEM_LIST_ELEMENT]) {
     const itemList = R.path([ITEM_LIST_ELEMENT], inputObj);
     val = flattenItemList(itemList);
+  }
+
+  if (inputObj['@type'].includes(AUDIO_OBJECT)) {
+    val = {
+      contentUrl: languageListToObject(inputObj[CONTENT_URL]),
+      transcript: languageListToObject(inputObj[TRANSCRIPT]),
+    };
   }
 
   return {

--- a/app/scenes/Activity/index.js
+++ b/app/scenes/Activity/index.js
@@ -53,7 +53,8 @@ const Activity = ({
   const { activity, responses } = currentResponse;
 
   // Hide the header and footer if it's a certain type of widget
-  const inputType = R.path(['items', currentScreen, 'inputType'], activity);
+  const currentItem = R.path(['items', currentScreen], activity);
+  const inputType = R.path(['inputType'], currentItem);
   const fullScreen = inputType === 'visual-stimulus-response';
 
   return (
@@ -66,11 +67,15 @@ const Activity = ({
         currentScreen={currentScreen}
         onChange={(answer) => {
           setAnswer(activity.id, currentScreen, answer);
-          if (inputType === 'visual-stimulus-response' || inputType === 'slider') {
+          if (inputType === 'visual-stimulus-response'
+            || inputType === 'slider') {
             nextScreen();
           }
           if (inputType === 'radio'
-            && R.path(['items', currentScreen, 'valueConstraints', 'multipleChoice'], activity) !== true) {
+            && R.path(['valueConstraints', 'multipleChoice'], currentItem) !== true) {
+            nextScreen();
+          }
+          if (inputType === 'audioStimulus' && R.path(['inputs', 'autoAdvance'], currentItem)) {
             nextScreen();
           }
         }}

--- a/app/scenes/Activity/index.js
+++ b/app/scenes/Activity/index.js
@@ -93,7 +93,7 @@ const Activity = ({
             prevLabel={getPrevLabel(currentScreen, itemVisibility)}
             prevEnabled
             onPressPrev={prevScreen}
-            actionLabel={getActionLabel(currentScreen, responses)}
+            actionLabel={getActionLabel(currentScreen, responses, activity.items)}
             onPressAction={() => { setAnswer(activity.id, currentScreen, undefined); }}
           />
         </View>

--- a/app/scenes/ActivityDetails/index.js
+++ b/app/scenes/ActivityDetails/index.js
@@ -11,7 +11,6 @@ class ActivityDetails extends Component {
   handleStartActivity = (activity) => {
     const { startResponse } = this.props;
     startResponse(activity);
-    Actions.push('take_act');
   }
 
   handleBack = () => {

--- a/app/services/activityNavigation.js
+++ b/app/services/activityNavigation.js
@@ -70,9 +70,13 @@ export const getPrevLabel = (index, visibility) => {
   return RETURN;
 };
 
-export const getActionLabel = (index, responses) => {
+export const getActionLabel = (index, responses, items) => {
   const response = responses[index];
-  return response === null || typeof response === 'undefined'
-    ? undefined
-    : UNDO;
+  if (response === null || typeof response === 'undefined') {
+    return undefined;
+  }
+  if (items[index].inputType === 'audioStimulus') {
+    return undefined;
+  }
+  return UNDO;
 };

--- a/app/services/file.js
+++ b/app/services/file.js
@@ -3,16 +3,14 @@ import RNFetchBlob from 'rn-fetch-blob';
 
 const deleteFile = path => RNFetchBlob.fs.unlink(path.replace('file://', ''));
 
-export const cleanFiles = (queuedUpload) => {
-  const responses = R.pathOr([], ['payload', 'responses'], queuedUpload);
+export const cleanFiles = (responses) => {
   responses.forEach((response) => {
-    const { data } = response;
-    if (data && data.survey && data.survey.uri) {
-      deleteFile(data.survey.uri);
-    } else if (data && data.canvas && data.canvas.uri) {
-      deleteFile(data.canvas.uri);
-    } else if (data && data.uri) {
-      deleteFile(data.uri);
+    if (response && response.survey && response.survey.uri) {
+      deleteFile(response.survey.uri);
+    } else if (response && response.canvas && response.canvas.uri) {
+      deleteFile(response.canvas.uri);
+    } else if (response && response.uri) {
+      deleteFile(response.uri);
     }
   });
 };

--- a/app/state/applets/applets.thunks.js
+++ b/app/state/applets/applets.thunks.js
@@ -24,6 +24,7 @@ export const downloadApplets = () => (dispatch, getState) => {
   const userInfo = userInfoSelector(state);
   dispatch(setDownloadingApplets(true));
   getApplets(auth.token, userInfo._id).then((applets) => {
+    console.log(applets);
     if (loggedInSelector(getState())) { // Check that we are still logged in when fetch finishes
       const transformedApplets = applets.map(applet => transformApplet(applet));
       dispatch(replaceApplets(transformedApplets));

--- a/app/state/applets/applets.thunks.js
+++ b/app/state/applets/applets.thunks.js
@@ -24,7 +24,6 @@ export const downloadApplets = () => (dispatch, getState) => {
   const userInfo = userInfoSelector(state);
   dispatch(setDownloadingApplets(true));
   getApplets(auth.token, userInfo._id).then((applets) => {
-    console.log(applets);
     if (loggedInSelector(getState())) { // Check that we are still logged in when fetch finishes
       const transformedApplets = applets.map(applet => transformApplet(applet));
       dispatch(replaceApplets(transformedApplets));

--- a/app/state/responses/responses.thunks.js
+++ b/app/state/responses/responses.thunks.js
@@ -2,6 +2,7 @@ import * as R from 'ramda';
 import { Alert } from 'react-native';
 import { Actions } from 'react-native-router-flux';
 import { downloadAllResponses, uploadResponseQueue } from '../../services/api';
+import { cleanFiles } from '../../services/file';
 import { prepareResponseForUpload } from '../../models/response';
 import { scheduleAndSetNotifications } from '../applets/applets.thunks';
 import { appletsSelector } from '../applets/applets.selectors';
@@ -18,7 +19,6 @@ import {
   addToUploadQueue,
   shiftUploadQueue,
   setCurrentScreen,
-  setAnswer,
 } from './responses.actions';
 import {
   setCurrentActivity,
@@ -43,6 +43,9 @@ export const startResponse = activity => (dispatch, getState) => {
   if (typeof responses.inProgress[activity.id] === 'undefined') {
     // There is no response in progress, so start a new one
     dispatch(createResponseInProgress(activity, subjectId, timeStarted));
+    dispatch(setCurrentScreen(activity.id, 0));
+    dispatch(setCurrentActivity(activity.id));
+    Actions.push('take_act');
   } else {
     Alert.alert(
       'Resume activity',
@@ -51,6 +54,8 @@ export const startResponse = activity => (dispatch, getState) => {
         {
           text: 'Restart',
           onPress: () => {
+            const itemResponses = R.pathOr([], ['inProgress', activity.id, 'responses'], responses);
+            cleanFiles(itemResponses);
             dispatch(createResponseInProgress(activity, subjectId, timeStarted));
             dispatch(setCurrentScreen(activity.id, 0));
             dispatch(setCurrentActivity(activity.id));

--- a/app/state/responses/responses.thunks.js
+++ b/app/state/responses/responses.thunks.js
@@ -1,4 +1,5 @@
 import * as R from 'ramda';
+import { Alert } from 'react-native';
 import { Actions } from 'react-native-router-flux';
 import { downloadAllResponses, uploadResponseQueue } from '../../services/api';
 import { prepareResponseForUpload } from '../../models/response';
@@ -42,10 +43,32 @@ export const startResponse = activity => (dispatch, getState) => {
   if (typeof responses.inProgress[activity.id] === 'undefined') {
     // There is no response in progress, so start a new one
     dispatch(createResponseInProgress(activity, subjectId, timeStarted));
+  } else {
+    Alert.alert(
+      'Resume activity',
+      'Would you like to resume this activity in progress or restart?',
+      [
+        {
+          text: 'Restart',
+          onPress: () => {
+            dispatch(createResponseInProgress(activity, subjectId, timeStarted));
+            dispatch(setCurrentScreen(activity.id, 0));
+            dispatch(setCurrentActivity(activity.id));
+            Actions.push('take_act');
+          },
+        },
+        {
+          text: 'Resume',
+          onPress: () => {
+            dispatch(setCurrentScreen(activity.id, 0));
+            dispatch(setCurrentActivity(activity.id));
+            Actions.push('take_act');
+          },
+        },
+      ],
+      { cancelable: false },
+    );
   }
-
-  dispatch(setCurrentScreen(activity.id, 0));
-  dispatch(setCurrentActivity(activity.id));
 };
 
 export const downloadResponses = () => (dispatch, getState) => {

--- a/app/store.js
+++ b/app/store.js
@@ -11,6 +11,7 @@ export default function configureStore(onCompletion) {
     key: 'root-v2',
     storage,
     // whitelist: [],
+    blacklist: ['form'],
   };
 
   const persistedReducer = persistReducer(persistConfig, rootReducer);

--- a/app/widgets/audio-widgets/AudioPlayer.js
+++ b/app/widgets/audio-widgets/AudioPlayer.js
@@ -1,0 +1,145 @@
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import PropTypes from 'prop-types';
+import { Icon } from 'native-base';
+import { Player } from 'react-native-audio-toolkit';
+import { colors } from '../../themes/colors';
+
+const styles = StyleSheet.create({
+  playButton: {
+    borderRadius: 3,
+    backgroundColor: colors.primary,
+    padding: 16,
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    width: 160,
+    marginRight: 16,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.2,
+    shadowRadius: 5,
+    elevation: 1,
+  },
+  buttonText: {
+    fontWeight: 'bold',
+    color: 'white',
+    fontSize: 18,
+    marginLeft: 5,
+    marginRight: 5,
+  },
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  infoText: {
+    color: colors.tertiary,
+    fontSize: 16,
+  },
+});
+
+export class AudioPlayer extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      playing: false,
+      player: null,
+      playbackCount: 0,
+    };
+  }
+
+  play = () => {
+    const { source, onEnd } = this.props;
+    const { playbackCount } = this.state;
+    const p = new Player(source);
+    p.play();
+    this.setState({
+      player: p,
+      playing: true,
+      playbackCount: playbackCount + 1,
+    });
+
+    // Listen for end of track
+    p.on('ended', () => {
+      this.setState({ playing: false });
+      onEnd();
+    });
+  }
+
+  stop = () => {
+    const { player } = this.state;
+    this.setState({ playing: false });
+    player.stop();
+  }
+
+  reset = () => {
+    const { player, playing } = this.state;
+    if (playing) {
+      player.stop();
+    }
+    this.setState({
+      player: null,
+      playing: false,
+      playbackCount: 0,
+    });
+  }
+
+  render() {
+    const { allowReplay } = this.props;
+    const { playing, playbackCount } = this.state;
+
+    if (playing && allowReplay) {
+      return (
+        <TouchableOpacity onPress={this.stop}>
+          <View style={styles.playButton}>
+            <Text style={styles.buttonText}>STOP</Text>
+            <Icon style={styles.buttonText} type="FontAwesome" name="stop" />
+            {/* <Text>{elapsed}</Text> */}
+          </View>
+        </TouchableOpacity>
+      );
+    }
+
+    if (playing) {
+      return (
+        <TouchableOpacity disabled>
+          <View style={[styles.playButton, { opacity: 0.5 }]}>
+            <Text style={styles.buttonText}>PLAYING...</Text>
+            <Icon style={styles.buttonText} type="FontAwesome" name="volume-up" />
+          </View>
+        </TouchableOpacity>
+      );
+    }
+
+    if (playbackCount === 0 || allowReplay) {
+      return (
+        <TouchableOpacity onPress={this.play}>
+          <View style={styles.playButton}>
+            <Text style={styles.buttonText}>PLAY</Text>
+            <Icon style={styles.buttonText} type="FontAwesome" name="play" />
+          </View>
+        </TouchableOpacity>
+      );
+    }
+
+    return (
+      <TouchableOpacity disabled>
+        <View style={[styles.playButton, { opacity: 0.5 }]}>
+          <Text style={styles.buttonText}>DONE</Text>
+          <Icon style={styles.buttonText} type="FontAwesome" name="check" />
+        </View>
+      </TouchableOpacity>
+    );
+  }
+}
+
+AudioPlayer.defaultProps = {
+  allowReplay: true,
+  onEnd: undefined,
+};
+
+AudioPlayer.propTypes = {
+  source: PropTypes.string.isRequired,
+  allowReplay: PropTypes.bool,
+  onEnd: PropTypes.func,
+};

--- a/app/widgets/audio-widgets/AudioRecorder.js
+++ b/app/widgets/audio-widgets/AudioRecorder.js
@@ -50,7 +50,11 @@ export default class AudioRecorder extends Component {
     const filename = Platform.OS === 'android'
       ? `${randomString({ length: 20 })}.mp4`
       : `${randomString({ length: 20 })}.aac`;
-    recorder = new Recorder(filename);
+    recorder = new Recorder(filename, {
+      bitrate: 128000,
+      channels: 1,
+      sampleRate: 44100,
+    });
 
     // Delete old recording if there is one
     if (this.state.path !== null) {

--- a/app/widgets/audio-widgets/AudioStimulus.js
+++ b/app/widgets/audio-widgets/AudioStimulus.js
@@ -5,7 +5,7 @@ import { AudioPlayer } from './AudioPlayer';
 
 export class AudioStimulus extends Component {
   componentDidUpdate(oldProps) {
-    const { isCurrent, config } = this.props;
+    const { isCurrent, config, value } = this.props;
     if (isCurrent && oldProps.isCurrent !== isCurrent) {
       if (config.autoStart) {
         // auto start the audio player
@@ -13,7 +13,11 @@ export class AudioStimulus extends Component {
       }
     } else if (!isCurrent && oldProps.isCurrent !== isCurrent) {
       // Stop the audio player if it isn't the current screen
-      this.player.reset();
+      if (value === false) {
+        this.player.reset();
+      } else {
+        this.player.stop();
+      }
     }
   }
 
@@ -33,6 +37,7 @@ export class AudioStimulus extends Component {
 }
 
 AudioStimulus.defaultProps = {
+  value: false,
   config: {
     stimulus: {},
     autoStart: false,
@@ -40,6 +45,7 @@ AudioStimulus.defaultProps = {
 };
 
 AudioStimulus.propTypes = {
+  value: PropTypes.bool,
   onChange: PropTypes.func.isRequired,
   isCurrent: PropTypes.bool.isRequired,
   config: PropTypes.shape({

--- a/app/widgets/audio-widgets/AudioStimulus.js
+++ b/app/widgets/audio-widgets/AudioStimulus.js
@@ -1,0 +1,53 @@
+import React, { Component } from 'react';
+import { View } from 'react-native';
+import PropTypes from 'prop-types';
+import { AudioPlayer } from './AudioPlayer';
+
+export class AudioStimulus extends Component {
+  componentDidUpdate(oldProps) {
+    const { isCurrent, config } = this.props;
+    if (isCurrent && oldProps.isCurrent !== isCurrent) {
+      if (config.autoStart) {
+        // auto start the audio player
+        this.player.start();
+      }
+    } else if (!isCurrent && oldProps.isCurrent !== isCurrent) {
+      // Stop the audio player if it isn't the current screen
+      this.player.reset();
+    }
+  }
+
+  render() {
+    const { config, onChange } = this.props;
+    return (
+      <View style={{ paddingTop: 16, paddingBottom: 16 }}>
+        <AudioPlayer
+          source={config.stimulus.contentUrl.en}
+          ref={(ref) => { this.player = ref; }}
+          allowReplay={config.allowReplay}
+          onEnd={() => onChange(true)}
+        />
+      </View>
+    );
+  }
+}
+
+AudioStimulus.defaultProps = {
+  config: {
+    stimulus: {},
+    autoStart: false,
+  },
+};
+
+AudioStimulus.propTypes = {
+  onChange: PropTypes.func.isRequired,
+  isCurrent: PropTypes.bool.isRequired,
+  config: PropTypes.shape({
+    stimulus: PropTypes.shape({
+      contentUrl: PropTypes.object,
+    }),
+    autoStart: PropTypes.bool,
+    autoAdvance: PropTypes.bool,
+    allowReplay: PropTypes.bool,
+  }),
+};

--- a/app/widgets/index.js
+++ b/app/widgets/index.js
@@ -1,5 +1,6 @@
-export * from './audio-widgets/AudioRecord';
 export * from './audio-widgets/AudioImageRecord';
+export * from './audio-widgets/AudioRecord';
+export * from './audio-widgets/AudioStimulus';
 export * from './DatePicker';
 export * from './MultiSelect';
 export * from './Radio';

--- a/ios/MDCApp.xcodeproj/project.pbxproj
+++ b/ios/MDCApp.xcodeproj/project.pbxproj
@@ -5,6 +5,7 @@
 	};
 	objectVersion = 46;
 	objects = {
+
 /* Begin PBXBuildFile section */
 		00C302E51ABCBA2D00DB3ED1 /* libRCTActionSheet.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302AC1ABCB8CE00DB3ED1 /* libRCTActionSheet.a */; };
 		00C302E71ABCBA2D00DB3ED1 /* libRCTGeolocation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302BA1ABCB90400DB3ED1 /* libRCTGeolocation.a */; };
@@ -59,6 +60,7 @@
 		832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 832341B51AAA6A8300B99B32 /* libRCTText.a */; };
 		8C2CFA2703A0454F8FDD3B84 /* MaterialIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = E1E174ED88DC4E5E9ED37650 /* MaterialIcons.ttf */; };
 		95F5AFF20A9E4EF2AA4AC013 /* EvilIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 4399C84D7D104BFD9AA3D256 /* EvilIcons.ttf */; };
+		AD8854BEC2C64215B92A4781 /* libRNCNetInfo-tvOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1942FDF39CF24589B1CABA5C /* libRNCNetInfo-tvOS.a */; };
 		ADBDB9381DFEBF1600ED6528 /* libRCTBlob.a in Frameworks */ = {isa = PBXBuildFile; fileRef = ADBDB9271DFEBF0700ED6528 /* libRCTBlob.a */; };
 		B54663317EBB4E34A51B2E3B /* SimpleLineIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 9944F09386AC4BA1A3A27C1E /* SimpleLineIcons.ttf */; };
 		C804D0B36AB54D459363C6B6 /* libRNFetchBlob.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 08C3E825F105484FA2B7C78E /* libRNFetchBlob.a */; };
@@ -66,12 +68,11 @@
 		D27DBEAD228CAB4200378289 /* JavaScriptCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D27DBE6F228CAB4200378289 /* JavaScriptCore.framework */; };
 		D5630D0CBDD442958135BB17 /* Feather.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 8D051F7996104DAEBD7BE7B7 /* Feather.ttf */; };
 		DDF81C9C22754FD3BAAC29D8 /* libReactNativeAudioToolkit.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 70488BCA5D7247D4B376B923 /* libReactNativeAudioToolkit.a */; };
+		E7A158CC419E4F0480F982FE /* libRNCNetInfo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 377FB7FC60664A3C9CB89CA9 /* libRNCNetInfo.a */; };
 		E8B4ADAE2EAC4C7097532095 /* FontAwesome5_Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 0144E243A98B4E36BF25459F /* FontAwesome5_Regular.ttf */; };
 		EA96CBA8794A4C45BE766879 /* Ionicons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = E67D95072BF64F618F605B9B /* Ionicons.ttf */; };
 		F4FA666142214DC98AB06CA1 /* libRNDeviceInfo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5665996285D148F6B9F92DF6 /* libRNDeviceInfo.a */; };
 		FC6914426D1A47D585609705 /* libRNVectorIcons.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9DCDEE04E7F74A8E989DAABB /* libRNVectorIcons.a */; };
-		E7A158CC419E4F0480F982FE /* libRNCNetInfo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 377FB7FC60664A3C9CB89CA9 /* libRNCNetInfo.a */; };
-		AD8854BEC2C64215B92A4781 /* libRNCNetInfo-tvOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1942FDF39CF24589B1CABA5C /* libRNCNetInfo-tvOS.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -390,6 +391,20 @@
 			remoteGlobalIDString = A15C300E1CD25C330074CB35;
 			remoteInfo = RNFetchBlob;
 		};
+		D255827E229F370300992598 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 185BD87C944C4876B66A4296 /* RNCNetInfo.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 134814201AA4EA6300B7C361;
+			remoteInfo = RNCNetInfo;
+		};
+		D2558280229F370300992598 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 185BD87C944C4876B66A4296 /* RNCNetInfo.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = B5027B1B2237B30F00F1AABA;
+			remoteInfo = "RNCNetInfo-tvOS";
+		};
 		D27DBE9A228CAB4200378289 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 146833FF1AC3E56700842450 /* React.xcodeproj */;
@@ -516,7 +531,9 @@
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = MDCApp/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = MDCApp/main.m; sourceTree = "<group>"; };
 		146833FF1AC3E56700842450 /* React.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = React.xcodeproj; path = "../node_modules/react-native/React/React.xcodeproj"; sourceTree = "<group>"; };
+		185BD87C944C4876B66A4296 /* RNCNetInfo.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNCNetInfo.xcodeproj; path = "../node_modules/@react-native-community/netinfo/ios/RNCNetInfo.xcodeproj"; sourceTree = "<group>"; };
 		18CF520DB6E04C1EA41B704A /* RNImagePicker.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNImagePicker.xcodeproj; path = "../node_modules/react-native-image-picker/ios/RNImagePicker.xcodeproj"; sourceTree = "<group>"; };
+		1942FDF39CF24589B1CABA5C /* libRNCNetInfo-tvOS.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = "libRNCNetInfo-tvOS.a"; sourceTree = "<group>"; };
 		1AD5CFA0CDF54C0F80854A12 /* libRNCWebView.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRNCWebView.a; sourceTree = "<group>"; };
 		1DB27F931FB6007700CA8F54 /* ART.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = ART.xcodeproj; path = "../node_modules/react-native/Libraries/ART/ART.xcodeproj"; sourceTree = "<group>"; };
 		24C4931029C7481E9D521E11 /* libReactNativePermissions.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libReactNativePermissions.a; sourceTree = "<group>"; };
@@ -524,6 +541,7 @@
 		2D02E47B1E0B4A5D006451C7 /* MDCApp-tvOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "MDCApp-tvOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		2D02E4901E0B4A5D006451C7 /* MDCApp-tvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "MDCApp-tvOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		35D6FE78135A46508828D4E3 /* rubicon-icon-font.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "rubicon-icon-font.ttf"; path = "../node_modules/native-base/Fonts/rubicon-icon-font.ttf"; sourceTree = "<group>"; };
+		377FB7FC60664A3C9CB89CA9 /* libRNCNetInfo.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRNCNetInfo.a; sourceTree = "<group>"; };
 		3A9A70C7F00F42258868D608 /* RNDeviceInfo.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNDeviceInfo.xcodeproj; path = "../node_modules/react-native-device-info/ios/RNDeviceInfo.xcodeproj"; sourceTree = "<group>"; };
 		3C2F9981AFCE42DEB9EC9DB6 /* AntDesign.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = AntDesign.ttf; path = "../node_modules/react-native-vector-icons/Fonts/AntDesign.ttf"; sourceTree = "<group>"; };
 		3E047D9968BF4108BA62E641 /* FontAwesome.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = FontAwesome.ttf; path = "../node_modules/native-base/Fonts/FontAwesome.ttf"; sourceTree = "<group>"; };
@@ -562,9 +580,6 @@
 		ED9DAE77C19146CF8F900A3F /* RNAudio.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNAudio.xcodeproj; path = "../node_modules/react-native-audio/ios/RNAudio.xcodeproj"; sourceTree = "<group>"; };
 		F995F616F3FC4DD0B246C5DE /* RNFetchBlob.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNFetchBlob.xcodeproj; path = "../node_modules/rn-fetch-blob/ios/RNFetchBlob.xcodeproj"; sourceTree = "<group>"; };
 		FEAA2F7D382D448C895FFC9A /* FontAwesome5_Brands.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = FontAwesome5_Brands.ttf; path = "../node_modules/react-native-vector-icons/Fonts/FontAwesome5_Brands.ttf"; sourceTree = "<group>"; };
-		185BD87C944C4876B66A4296 /* RNCNetInfo.xcodeproj */ = {isa = PBXFileReference; name = "RNCNetInfo.xcodeproj"; path = "../node_modules/@react-native-community/netinfo/ios/RNCNetInfo.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
-		377FB7FC60664A3C9CB89CA9 /* libRNCNetInfo.a */ = {isa = PBXFileReference; name = "libRNCNetInfo.a"; path = "libRNCNetInfo.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
-		1942FDF39CF24589B1CABA5C /* libRNCNetInfo-tvOS.a */ = {isa = PBXFileReference; name = "libRNCNetInfo-tvOS.a"; path = "libRNCNetInfo-tvOS.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -824,6 +839,8 @@
 				EB247A91F25F4967A8847537 /* libRNVectorIcons-tvOS.a */,
 				1AD5CFA0CDF54C0F80854A12 /* libRNCWebView.a */,
 				24C4931029C7481E9D521E11 /* libReactNativePermissions.a */,
+				377FB7FC60664A3C9CB89CA9 /* libRNCNetInfo.a */,
+				1942FDF39CF24589B1CABA5C /* libRNCNetInfo-tvOS.a */,
 			);
 			name = "Recovered References";
 			sourceTree = "<group>";
@@ -970,6 +987,15 @@
 			isa = PBXGroup;
 			children = (
 				D24469092278A2E40030E9C9 /* libRNFetchBlob.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		D255827A229F370300992598 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				D255827F229F370300992598 /* libRNCNetInfo.a */,
+				D2558281229F370300992598 /* libRNCNetInfo-tvOS.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1215,6 +1241,10 @@
 				{
 					ProductGroup = D7B3145B213DB68C0026C211 /* Products */;
 					ProjectRef = 5CC4A929D0574A01ABA23F51 /* RNCamera.xcodeproj */;
+				},
+				{
+					ProductGroup = D255827A229F370300992598 /* Products */;
+					ProjectRef = 185BD87C944C4876B66A4296 /* RNCNetInfo.xcodeproj */;
 				},
 				{
 					ProductGroup = D27DBEFA228CAF3000378289 /* Products */;
@@ -1551,6 +1581,20 @@
 			fileType = archive.ar;
 			path = libRNFetchBlob.a;
 			remoteRef = D24469082278A2E40030E9C9 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		D255827F229F370300992598 /* libRNCNetInfo.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libRNCNetInfo.a;
+			remoteRef = D255827E229F370300992598 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		D2558281229F370300992598 /* libRNCNetInfo-tvOS.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libRNCNetInfo-tvOS.a";
+			remoteRef = D2558280229F370300992598 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 		D27DBE9B228CAB4200378289 /* libjsi.a */ = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
  "name": "MindLogger",
- "version": "0.2.3",
+ "version": "0.2.6",
  "private": true,
  "scripts": {
   "start": "node node_modules/react-native/local-cli/cli.js start",


### PR DESCRIPTION
 - Adds an `AudioStimulus` widget for playing an audio file. It can be configured to play as soon as the user gets to the screen, and to advance to the next screen automatically once playback is complete. It can also be configured so that the user can only listen once, or to allow the user to stop and replay the file. The widget sets a flag when the user has listened all the way through so that we can see on the admin panel that the stimulus was listened to.
 - Makes some minor code fixes to how we navigate activities
 - Improves the cleanup of files to ensure all files are deleted when the user logs out or restarts an activity
 - When user tries to start an activity already in progress, the app will prompt them for whether they want to restart the activity or continue

![image](https://user-images.githubusercontent.com/14841718/58596432-0c75a600-8242-11e9-88dd-b3b81645caeb.png)

![image](https://user-images.githubusercontent.com/14841718/58596437-17303b00-8242-11e9-9563-fc6af8499b12.png)

![image](https://user-images.githubusercontent.com/14841718/58596445-1f887600-8242-11e9-90cb-26d16f241f4a.png)

