### PR TITLE
Feature/reskinning

### DIFF
--- a/app/scenes/Login/index.js
+++ b/app/scenes/Login/index.js
@@ -65,7 +65,6 @@ class Login extends Component {
     const { skin, mobileDataAllowed, toggleMobileDataAllowed } = this.props;
     const title = skin.name;
     const logo = (typeof skin.logo !== 'undefined') ? { uri: skin.logo } : defaultLogo;
-    console.log(logo);
     return (
       <Container>
         <StatusBar barStyle="light-content" />

--- a/app/scenes/Login/index.js
+++ b/app/scenes/Login/index.js
@@ -19,7 +19,7 @@ import LoginForm from './LoginForm';
 import { skinSelector, mobileDataAllowedSelector } from '../../state/app/app.selectors';
 import { toggleMobileDataAllowed } from '../../state/app/app.actions';
 
-const logoImage = require('../../../img/CMI_white_logo.png');
+const defaultLogo = require('../../../img/CMI_white_logo.png');
 
 class Login extends Component {
   onRegister = () => {
@@ -63,7 +63,9 @@ class Login extends Component {
 
   render() {
     const { skin, mobileDataAllowed, toggleMobileDataAllowed } = this.props;
-    const title = skin ? skin.name : 'MindLogger';
+    const title = skin.name;
+    const logo = (typeof skin.logo !== 'undefined') ? { uri: skin.logo } : defaultLogo;
+    console.log(logo);
     return (
       <Container>
         <StatusBar barStyle="light-content" />
@@ -93,7 +95,7 @@ class Login extends Component {
             <Image
               square
               style={styles.logo}
-              source={logoImage}
+              source={logo}
             />
           </View>
         </Content>

--- a/app/scenes/Sidebar/index.js
+++ b/app/scenes/Sidebar/index.js
@@ -44,7 +44,8 @@ const datas = [
   },
 ];
 
-const logoImage = require('../../../img/color_logo.png');
+const defaultLogo = require('../../../img/color_logo.png');
+
 class SideBar extends Component {
 
   static propTypes = {
@@ -73,6 +74,7 @@ class SideBar extends Component {
   render() {
     const { skin } = this.props;
     const title = skin ? skin.name : 'MindLogger';
+    const logo = (typeof skin.logo !== 'undefined') ? { uri: skin.logo } : defaultLogo;
     return (
       <Container>
         <Content
@@ -107,7 +109,7 @@ class SideBar extends Component {
             <Image
                 square
                 style={styles.drawerLogo}
-                source={logoImage}
+                source={logo}
                 />
           </View>
 

--- a/app/scenes/Sidebar/index.js
+++ b/app/scenes/Sidebar/index.js
@@ -2,21 +2,20 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Image } from 'react-native';
 import { connect } from 'react-redux';
-import { Content, Text, List, ListItem, Container, Left, Right, Badge, View, Header, Body, Title, Icon } from 'native-base';
+import { Content, Text, List, ListItem, Container, Left, Header, Body, Title, Icon } from 'native-base';
 import { Actions } from 'react-native-router-flux';
 import styles from './style';
 import { logout } from '../../state/app/app.thunks';
 import { skinSelector } from '../../state/app/app.selectors';
 
 
-const datas = [
+const sidebarData = [
   {
     name: 'Home',
     route: 'applet_list',
     icon: 'home',
     type: 'FontAwesome',
     image: require('../../../img/menu/diagram.png'),
-    bg: '#C5F442',
   },
   {
     name: 'Settings',
@@ -24,7 +23,6 @@ const datas = [
     icon: 'gear',
     type: 'FontAwesome',
     image: require('../../../img/menu/settings.png'),
-    bg: '#DA4437',
   },
   {
     name: 'About',
@@ -32,7 +30,6 @@ const datas = [
     icon: 'question',
     type: 'FontAwesome',
     image: require('../../../img/menu/info.png'),
-    bg: '#4DCAE0',
   },
   {
     name: 'Logout',
@@ -40,29 +37,14 @@ const datas = [
     icon: 'sign-out',
     type: 'FontAwesome',
     image: require('../../../img/menu/logout.png'),
-    bg: '#1EBC7C',
   },
 ];
 
 const defaultLogo = require('../../../img/color_logo.png');
 
 class SideBar extends Component {
-
-  static propTypes = {
-    changePlatform: PropTypes.func,
-    changeMaterial: PropTypes.func,
-  }
-
-  constructor(props) {
-    super(props);
-    this.state = {
-      shadowOffsetWidth: 1,
-      shadowRadius: 4,
-    };
-  }
-
-  onMenu(route) {
-    const { closeDrawer, logout } = this.props;
+  onMenu = (route) => {
+    const { logout } = this.props;
     if (route === 'logout') {
       logout();
     } else {
@@ -73,58 +55,53 @@ class SideBar extends Component {
 
   render() {
     const { skin } = this.props;
-    const title = skin ? skin.name : 'MindLogger';
+    const title = skin.name;
     const logo = (typeof skin.logo !== 'undefined') ? { uri: skin.logo } : defaultLogo;
     return (
       <Container>
         <Content
           bounces={false}
-          style={{ flex: 1, backgroundColor: '#fff', top: -1 }}
+          style={styles.content}
         >
           <Header style={{ backgroundColor: skin.colors.primary }}>
             <Body>
               <Title>{title}</Title>
             </Body>
           </Header>
-          <List style={styles.drawerList}
-            dataArray={datas} renderRow={data =>
-            <ListItem button noBorder onPress={() => this.onMenu(data.route)} >
-              <Left>
-                {/* <Image active source={data.image} style={styles.menuImage} /> */}
-                <Icon type={data.type} name={data.icon} />
-                <Text style={styles.text}>{data.name}</Text>
-              </Left>
-              {(data.types) &&
-              <Right style={{ flex: 1 }}>
-                <Badge
-                  style={{ borderRadius: 3, height: 25, width: 72, backgroundColor: data.bg }}
-                >
-                  <Text style={styles.badgeText}>{`${data.types} Types`}</Text>
-                </Badge>
-              </Right>
-              }
-            </ListItem>}
+          <List
+            style={styles.drawerList}
+            dataArray={sidebarData}
+            renderRow={data => (
+              <ListItem button noBorder onPress={() => this.onMenu(data.route)}>
+                <Left style={styles.drawerItem}>
+                  <Icon type={data.type} name={data.icon} />
+                  <Text style={styles.text}>{data.name}</Text>
+                </Left>
+              </ListItem>
+            )}
           />
-          <View>
-            <Image
-                square
-                style={styles.drawerLogo}
-                source={logo}
-                />
-          </View>
-
+          <Image
+            square
+            style={styles.drawerLogo}
+            source={logo}
+          />
         </Content>
       </Container>
     );
   }
 }
 
+SideBar.propTypes = {
+  skin: PropTypes.object.isRequired,
+  logout: PropTypes.func.isRequired,
+};
+
 const bindAction = {
   logout,
 };
 
 const mapStateToProps = state => ({
-  skin: skinSelector(state)
+  skin: skinSelector(state),
 });
 
 export default connect(mapStateToProps, bindAction)(SideBar);

--- a/app/scenes/Sidebar/style.js
+++ b/app/scenes/Sidebar/style.js
@@ -5,67 +5,35 @@ const React = require('react-native');
 const { Platform } = React;
 
 export default {
-  sidebar: {
+  content: {
     flex: 1,
-    backgroundColor: '#fff',
-  },
-  drawerCover: {
-    alignSelf: 'stretch',
-    // resizeMode: 'cover',
-    width: null,
-    backgroundColor: colors.primary,
-    position: 'relative',
-    marginBottom: 10,
-    flexDirection: 'row',
-  },
-  drawerCoverText: {
-    color: '#FFFFFF',
-    width: '100%',
-    fontSize: 24,
-    alignSelf: 'center',
-    textAlign: 'center',
+    backgroundColor:
+    '#fff',
+    top: -1
   },
   drawerList: {
     marginLeft: 20,
     marginTop: 20,
   },
-  menuImage: {
-    width: 36,
-    height: 36,
-    resizeMode: 'contain',
+  drawerItem: {
+    alignItems: 'center',
   },
   drawerLogo: {
-    // left: (Platform.OS === 'android') ? 30 : 40,
-    //top: (Platform.OS === 'android') ? deviceHeight / 13 : deviceHeight / 12,
     marginTop: 40,
     alignSelf: 'center',
     width: 94,
     height: 79,
     resizeMode: 'contain',
   },
-  listItemContainer: {
-    flexDirection: 'row',
-    justifyContent: 'flex-start',
-    alignItems: 'center',
-  },
-  iconContainer: {
-    width: 37,
-    height: 37,
-    borderRadius: 18,
-    marginRight: 12,
-    paddingTop: (Platform.OS === 'android') ? 7 : 5,
-  },
-  sidebarIcon: {
-    fontSize: 18,
-    color: '#fff',
-    lineHeight: (Platform.OS === 'android') ? 21 : 25,
-    backgroundColor: 'transparent',
-    alignSelf: 'center',
-  },
   text: {
-    fontWeight: (Platform.OS === 'ios') ? '300' : '300',
+    fontWeight: '300',
     fontSize: 20,
     marginLeft: 20,
+  },
+  badge: {
+    borderRadius: 3,
+    height: 25,
+    width: 72,
   },
   badgeText: {
     fontSize: (Platform.OS === 'ios') ? 13 : 11,


### PR DESCRIPTION
- Add logo reskinning to ```Login``` and ```Sidebar```
    - Logo can be reskinned with an optional ```logo``` field containing a base64 encoded image string. 
    - For example: ```logo: 'data:image/jpeg;base64,/9j/4AAQSkZJR ...```
    - If no logo field is provided, default CMI logo will be used
- Refactor ```Sidebar``` scene
    - Purge unused styles from ```styles.js``` and move inline styles to ```styles.js```
    - Center icons and text vertically so they are now aligned
    - **Lint lint lint**

<img src="https://user-images.githubusercontent.com/31543235/58643819-aaf71b00-82c5-11e9-8c88-fc86abede93a.png" width="200">

