### PR TITLE
Improve drawing widgets; Add "join demo applet" link

### DIFF
--- a/app/components/JoinDemoApplets.js
+++ b/app/components/JoinDemoApplets.js
@@ -28,6 +28,10 @@ const DEMO_APPLETS = [
     label: 'Cognitive Tasks',
     uri: 'https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activity-sets/cognitive-tasks/cognitive-tasks_schema.jsonld',
   },
+  {
+    label: 'MindLogger Demos',
+    uri: 'https://raw.githubusercontent.com/stufreen/schema-standardization/widget-demo-activity/activity-sets/mindlogger-demo/mindlogger-demo_schema.jsonld',
+  },
 ];
 
 const appletsInclude = (applets, appletSchemaURI) => {

--- a/app/components/screen/ScreenDisplay.js
+++ b/app/components/screen/ScreenDisplay.js
@@ -5,7 +5,7 @@ import Markdown from 'react-native-easy-markdown';
 import { markdownStyle } from '../../themes/activityTheme';
 
 const ScreenDisplay = ({ screen }) => (
-  <View>
+  <View style={{ marginBottom: 18 }}>
     {screen.preamble && <Markdown markdownStyles={markdownStyle}>{screen.preamble.en}</Markdown>}
     {screen.question && <Markdown markdownStyles={markdownStyle}>{screen.question.en}</Markdown>}
   </View>

--- a/app/components/screen/index.js
+++ b/app/components/screen/index.js
@@ -167,6 +167,7 @@ class Screen extends Component {
     if (screen.inputType === 'drawing') {
       return (
         <Drawing
+          config={screen.inputs}
           onChange={onChange}
           value={answer}
         />

--- a/app/components/screen/index.js
+++ b/app/components/screen/index.js
@@ -16,6 +16,7 @@ import {
   TextEntry,
   TimeRange,
   VisualStimulusResponse,
+  Drawing,
 } from '../../widgets';
 
 const styles = StyleSheet.create({
@@ -160,6 +161,14 @@ class Screen extends Component {
           onChange={onChange}
           config={screen.inputs}
           isCurrent={isCurrent}
+        />
+      );
+    }
+    if (screen.inputType === 'drawing') {
+      return (
+        <Drawing
+          onChange={onChange}
+          value={answer}
         />
       );
     }

--- a/app/models/json-ld.js
+++ b/app/models/json-ld.js
@@ -7,6 +7,7 @@ const CONTENT_URL = 'http://schema.org/contentUrl';
 const DESCRIPTION = 'http://schema.org/description';
 const DO_NOT_KNOW = 'https://schema.repronim.org/dont_know_answer';
 const IMAGE = 'http://schema.org/image';
+const IMAGE_OBJECT = 'http://schema.org/ImageObject';
 const INPUT_TYPE = 'https://schema.repronim.org/inputType';
 const INPUTS = 'https://schema.repronim.org/inputs';
 const IS_ABOUT = 'https://schema.repronim.org/isAbout';
@@ -102,6 +103,12 @@ export const transformInputs = inputs => inputs.reduce((accumulator, inputObj) =
     };
   }
 
+  if (inputObj['@type'].includes(IMAGE_OBJECT)) {
+    val = {
+      contentUrl: languageListToObject(inputObj[CONTENT_URL]),
+    };
+  }
+
   return {
     ...accumulator,
     [key]: val,
@@ -161,7 +168,7 @@ export const itemAttachExtras = (
   ...transformedItem,
   schema: schemaUri,
   variableName: variableMap[schemaUri],
-  visibility: visibilityObj[variableMap[schemaUri]]
+  visibility: visibilityObj[variableMap[schemaUri]],
 });
 
 export const activityTransformJson = (activityJson, itemsJson) => {

--- a/app/themes/activityTheme.js
+++ b/app/themes/activityTheme.js
@@ -67,6 +67,21 @@ export default styles = StyleSheet.create({
 });
 
 export const markdownStyle = {
+  h1: {
+    fontSize: 36,
+    fontWeight: 'bold',
+    marginBottom: 18,
+  },
+  h2: {
+    fontSize: 30,
+    fontWeight: 'bold',
+    marginBottom: 18,
+  },
+  h3: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: 18,
+  },
   text: {
     alignSelf: 'flex-start',
     fontSize: 18,

--- a/app/widgets/Drawing/DrawingBoard.js
+++ b/app/widgets/Drawing/DrawingBoard.js
@@ -1,12 +1,8 @@
-import React, {Component} from 'react';
-import {View, PanResponder, Image, StyleSheet} from 'react-native';
-import {Icon} from 'native-base';
-
-import Svg,{
-    Polyline,
-} from 'react-native-svg';
-
-import { GImage } from '../core';
+import React, { Component } from 'react';
+import { View, PanResponder, Image, StyleSheet } from 'react-native';
+import { Icon } from 'native-base';
+import Svg, { Polyline } from 'react-native-svg';
+import { GImage } from '../../components/core';
 
 const styles = StyleSheet.create({
     picture: {width: '100%', height:'100%', resizeMode: 'cover'},

--- a/app/widgets/Drawing/DrawingBoard.js
+++ b/app/widgets/Drawing/DrawingBoard.js
@@ -1,186 +1,204 @@
 import React, { Component } from 'react';
-import { View, PanResponder, Image, StyleSheet } from 'react-native';
-import { Icon } from 'native-base';
+import PropTypes from 'prop-types';
+import { View, PanResponder, StyleSheet } from 'react-native';
 import Svg, { Polyline } from 'react-native-svg';
 import { GImage } from '../../components/core';
 
 const styles = StyleSheet.create({
-    picture: {width: '100%', height:'100%', resizeMode: 'cover'},
-    blank:{width: '100%', height:'100%', position:'absolute', borderWidth: 1, borderColor: '#d6d7da'},
-})
+  picture: {
+    width: '100%',
+    height: '100%',
+    resizeMode: 'cover',
+  },
+  blank: {
+    width: '100%',
+    height: '100%',
+    position: 'absolute',
+    borderWidth: 1,
+    borderColor: '#d6d7da',
+  },
+});
 
-function chunckedPointStr(lines, chunkSize){
-    var results = [];
-    lines.forEach(line => {
-        let length = line.points.length
-        for (var index = 0; index < length ; index += chunkSize) {
-            myChunk = line.points.slice(index, index+chunkSize+1);
-            // Do something if you want with the group
-            results.push(myChunk.map(point => point.x + "," + point.y).join(" "));
-        }
-    });
-    return results;
+function chunkedPointStr(lines, chunkSize) {
+  const results = [];
+  lines.forEach((line) => {
+    const { length } = line.points;
+    for (let index = 0; index < length; index += chunkSize) {
+      const myChunk = line.points.slice(index, index + chunkSize + 1);
+      // Do something if you want with the group
+      results.push(myChunk.map(point => `${point.x},${point.y}`).join(' '));
+    }
+  });
+  return results;
 }
-
 
 export default class DrawingBoard extends Component {
-    constructor(props) {
-        super(props)
-        this.allowed = false
-        this.startX = 0
-        this.startY = 0
-        this.lastX = 0
-        this.lastY = 0
-    }
+  constructor(props) {
+    super(props);
+    this.allowed = false;
+    this.startX = 0;
+    this.startY = 0;
+    this.lastX = 0;
+    this.lastY = 0;
+  }
 
-    addLine = (evt, gestureState) => {
-        const {lines, startTime} = this.state
-        if(!this.allowed) return
+  componentWillMount() {
+    this._panResponder = PanResponder.create({
+      // Ask to be the responder:
+      onStartShouldSetPanResponder: () => true,
+      onStartShouldSetPanResponderCapture: () => true,
+      onMoveShouldSetPanResponder: () => true,
+      onMoveShouldSetPanResponderCapture: () => true,
+      onPanResponderGrant: this.addLine,
+      onPanResponderMove: this.addPoint,
+      onPanResponderTerminationRequest: () => true,
+      onPanResponderRelease: () => {
+        // The user has released all touches while this view is the
+        // responder. This typically means a gesture has succeeded
+        this.props.onResult(this.save());
+      },
+      onPanResponderTerminate: () => {
+        // Another component has become the responder, so this gesture
+        // should be cancelled
+      },
+      // Returns whether this component should block native components from becoming the JS
+      // responder. Returns true by default. Is currently only supported on android.
+      onShouldBlockNativeResponder: () => true,
+    });
+    this.setState({ lines: [] });
+    this.allowed = true;
+  }
 
-        const {locationX, locationY} = evt.nativeEvent
-        if(!startTime)
-            this.setState({startTime: (new Date()).getTime()})
-        this.startX = locationX
-        this.startY = locationY
-        lines.push({points:[{x:locationX, y:locationY, time:0}]})
-        this.setState({lines})
-    }
+  addLine = (evt) => {
+    const { lines, startTime } = this.state;
+    if (!this.allowed) return;
 
-    addPoint = (evt, gestureState) => {
-        const {lines, dimensions, startTime} = this.state
-        let time = Date.now() - startTime;
-        if(!this.allowed) return
-        let n = lines.length-1
-        const {moveX, moveY, x0, y0} = gestureState
-        const x = moveX-x0+this.startX
-        const y = moveY-y0+this.startY
-        if((Math.abs(this.lastX-x)>10) || (Math.abs(this.lastY-y)>10)) {
-            this.lastX = x
-            this.lastY = y
-            lines[n].points.push({ x: this.lastX, y:this.lastY, time})
-            this.setState({lines})
-        }
+    const { locationX, locationY } = evt.nativeEvent;
+    if (!startTime) {
+      this.setState({ startTime: (new Date()).getTime() });
     }
+    this.startX = locationX;
+    this.startY = locationY;
+    lines.push({ points: [{ x: locationX, y: locationY, time: 0 }] });
+    this.setState({ lines });
+  }
 
-    componentWillMount() {
-        this._panResponder = PanResponder.create({
-            // Ask to be the responder:
-            onStartShouldSetPanResponder: (evt, gestureState) => true,
-            onStartShouldSetPanResponderCapture: (evt, gestureState) => true,
-            onMoveShouldSetPanResponder: (evt, gestureState) => true,
-            onMoveShouldSetPanResponderCapture: (evt, gestureState) => true,
-      
-            onPanResponderGrant: this.addLine,
-            onPanResponderMove: this.addPoint,
-            onPanResponderTerminationRequest: (evt, gestureState) => true,
-            onPanResponderRelease: (evt, gestureState) => {
-              // The user has released all touches while this view is the
-              // responder. This typically means a gesture has succeeded
-              this.props.onResult(this.save());
-            },
-            onPanResponderTerminate: (evt, gestureState) => {
-              // Another component has become the responder, so this gesture
-              // should be cancelled
-            },
-            onShouldBlockNativeResponder: (evt, gestureState) => {
-              // Returns whether this component should block native components from becoming the JS
-              // responder. Returns true by default. Is currently only supported on android.
-              return true;
-            },
-          });
-        this.setState({lines: []})
-        if (this.props.autoStart) {
-            this.allowed = true
-        }
+  addPoint = (evt, gestureState) => {
+    const { lines, startTime } = this.state;
+    const time = Date.now() - startTime;
+    if (!this.allowed) return;
+    const n = lines.length - 1;
+    const { moveX, moveY, x0, y0 } = gestureState;
+    const x = moveX - x0 + this.startX;
+    const y = moveY - y0 + this.startY;
+    if ((Math.abs(this.lastX - x) > 10) || (Math.abs(this.lastY - y) > 10)) {
+      this.lastX = x;
+      this.lastY = y;
+      lines[n].points.push({ x: this.lastX, y: this.lastY, time });
+      this.setState({ lines });
     }
+  }
 
-    renderLine(pointStr, idx) {
-        return (<Polyline key={idx}
-            points={pointStr}
-            fill= 'none'
-            stroke="black"
-            strokeWidth="3"
-        />)
+  onLayout = (event) => {
+    if (this.state.dimensions) return; // layout was already called
+    const { width, height, top, left } = event.nativeEvent.layout;
+    if (this.props.lines && this.props.lines.length > this.state.lines.length) {
+      const lines = this.props.lines.map(line => ({
+        ...line,
+        points: line.points.map(point => ({
+          ...point,
+          x: point.x * width / 100,
+          y: point.y * width / 100,
+        })),
+      }));
+      this.setState({ dimensions: { width, height, top, left }, lines });
+    } else {
+      this.setState({ dimensions: { width, height, top, left } });
     }
+  }
 
-    onMove = (evt) => {
-        
-    }
-    reset(){
-        this.setState({lines:[], startTime:undefined})
-    }
-    start() {
-        this.reset()
-        this.allowed = true
-    }
+  reset() {
+    this.setState({ lines: [], startTime: undefined });
+  }
 
-    stop() {
-        this.allowed = false
-    }
+  start() {
+    this.reset();
+    this.allowed = true;
+  }
 
-    save() {
-        const {lines, startTime} = this.state
-        const { width } = this.state.dimensions
-        results = lines.map(line => ({
-            ...line,
-            points: line.points.map( point => ({
-                ...point,
-                x: point.x/width*100,
-                y: point.y/width*100
-                }))
-            })
-        )
-        return {lines: results, startTime}
-    }
+  stop() {
+    this.allowed = false;
+  }
 
-    render() {
-        const {lines, dimensions} = this.state
-        const {placeholder} = this.props
-        if (dimensions) {
-            var { width } = dimensions
-        }
-        if(!width)
-            width = 300
-        const strArray = chunckedPointStr(lines,50)
-        return (
-            
-            <View style={{width: '100%', height: width || 300, alignItems: 'center', backgroundColor: 'white'}} onLayout={this.onLayout} {...this._panResponder.panHandlers}>
-                
-                {this.props.source && (<Image style={styles.picture} source={this.props.source}/>)}
-                {this.props.sourceFiles && (<GImage style={styles.picture} file={this.props.sourceFiles}/>)}
-                {placeholder && (<Icon name="brush" style={{fontSize:120}}/>)}
-                <View style={styles.blank}>
-                    {dimensions && 
-                    <Svg
-                        height={width}
-                        width={width}
-                    >
-                    {strArray.map(this.renderLine)}
-                    </Svg>
-                    }
-                </View>
-            </View>
-        )
-    }
+  save() {
+    const { lines, startTime } = this.state;
+    const { width } = this.state.dimensions;
+    const results = lines.map(line => ({
+      ...line,
+      points: line.points.map(point => ({
+        ...point,
+        x: point.x / width * 100,
+        y: point.y / width * 100,
+      })),
+    }));
+    return { lines: results, startTime };
+  }
 
-    onLayout = event => {
-        if (this.state.dimensions) return // layout was already called
-        let {width, height, top, left} = event.nativeEvent.layout;
-        if (this.props.lines && this.props.lines.length > this.state.lines.length) {
-            let lines = this.props.lines.map(line => ({
-                ...line,
-                points: line.points.map( point => ({
-                    ...point,
-                    x: point.x*width/100,
-                    y: point.y*width/100
-                    }))
-                })
-            );
-            this.setState({dimensions: {width, height, top, left}, lines});
-        } else {
-            this.setState({dimensions: {width, height, top, left}});
-        }
-    }
+  renderLine = (pointStr, idx) => (
+    <Polyline
+      key={idx}
+      points={pointStr}
+      fill="none"
+      stroke="black"
+      strokeWidth="3"
+    />
+  );
+
+  render() {
+    const { lines, dimensions } = this.state;
+    const width = dimensions ? dimensions.width : 300;
+    const strArray = chunkedPointStr(lines, 50);
+
+    return (
+      <View
+        style={{
+          width: '100%',
+          height: width || 300,
+          alignItems: 'center',
+          backgroundColor: 'white',
+        }}
+        onLayout={this.onLayout}
+        {...this._panResponder.panHandlers}
+      >
+        {this.props.imageSource && (
+          <GImage
+            style={styles.picture}
+            file={this.props.imageSource}
+          />
+        )}
+        <View style={styles.blank}>
+          {dimensions && (
+            <Svg
+              height={width}
+              width={width}
+            >
+              {strArray.map(this.renderLine)}
+            </Svg>
+          )}
+        </View>
+      </View>
+    );
+  }
 }
 
-{/* <DrawingBoard source={drawing.image_url && {uri: drawing.image_url}} disabled={!started} ref={board => this.board = board}/> */}
+DrawingBoard.defaultProps = {
+  imageSource: null,
+  lines: [],
+  onResult: () => {},
+};
+
+DrawingBoard.propTypes = {
+  imageSource: PropTypes.string,
+  lines: PropTypes.array,
+  onResult: PropTypes.func,
+};

--- a/app/widgets/Drawing/DrawingBoard.js
+++ b/app/widgets/Drawing/DrawingBoard.js
@@ -2,9 +2,9 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { View, PanResponder, StyleSheet } from 'react-native';
 import Svg, { Polyline } from 'react-native-svg';
-import { GImage } from '../../components/core';
+import { CachedImage } from 'react-native-img-cache';
 
-const SENSITIVITY = 5;
+const SENSITIVITY = 30; // Milliseconds between line points (lower is more sensitive)
 
 const styles = StyleSheet.create({
   picture: {
@@ -96,7 +96,7 @@ export default class DrawingBoard extends Component {
     const { moveX, moveY, x0, y0 } = gestureState;
     const x = moveX - x0 + this.startX;
     const y = moveY - y0 + this.startY;
-    if (timeDelta > 30) {
+    if (timeDelta >= SENSITIVITY) {
       this.lastX = x;
       this.lastY = y;
       this.lastPressTimestamp = nowTimestamp;
@@ -177,9 +177,9 @@ export default class DrawingBoard extends Component {
         {...this._panResponder.panHandlers}
       >
         {this.props.imageSource && (
-          <GImage
+          <CachedImage
             style={styles.picture}
-            file={this.props.imageSource}
+            source={{ uri: this.props.imageSource }}
           />
         )}
         <View style={styles.blank}>

--- a/app/widgets/Drawing/index.js
+++ b/app/widgets/Drawing/index.js
@@ -7,7 +7,7 @@ const styles = StyleSheet.create({
   text: {
     paddingTop: 20,
     paddingBottom: 20,
-  }
+  },
 });
 
 export class Drawing extends React.Component {
@@ -23,8 +23,7 @@ export class Drawing extends React.Component {
     return (
       <View>
         <DrawingBoard
-          sourceFiles={config.mode === 'picture' && config.pictureFiles}
-          autoStart
+          imageSource={config.imageSource.en}
           lines={value && value.lines}
           onResult={onChange}
           ref={(ref) => { this.board = ref; }}
@@ -38,15 +37,13 @@ export class Drawing extends React.Component {
 }
 
 Drawing.defaultProps = {
-  config: {
-    mode: 'FREE_DRAW',
-  },
+  config: {},
   value: {},
 };
 
 Drawing.propTypes = {
   config: PropTypes.shape({
-    mode: PropTypes.string,
+    imageSource: PropTypes.string,
   }),
   value: PropTypes.object,
   onChange: PropTypes.func.isRequired,

--- a/app/widgets/Drawing/index.js
+++ b/app/widgets/Drawing/index.js
@@ -23,7 +23,7 @@ export class Drawing extends React.Component {
     return (
       <View>
         <DrawingBoard
-          imageSource={config.imageSource.en}
+          imageSource={config.backgroundImage ? config.backgroundImage.contentUrl.en : null}
           lines={value && value.lines}
           onResult={onChange}
           ref={(ref) => { this.board = ref; }}
@@ -37,9 +37,7 @@ export class Drawing extends React.Component {
 }
 
 Drawing.defaultProps = {
-  config: {
-    imageSource: {},
-  },
+  config: {},
   value: {},
 };
 

--- a/app/widgets/Drawing/index.js
+++ b/app/widgets/Drawing/index.js
@@ -37,13 +37,15 @@ export class Drawing extends React.Component {
 }
 
 Drawing.defaultProps = {
-  config: {},
+  config: {
+    imageSource: {},
+  },
   value: {},
 };
 
 Drawing.propTypes = {
   config: PropTypes.shape({
-    imageSource: PropTypes.string,
+    imageSource: PropTypes.object,
   }),
   value: PropTypes.object,
   onChange: PropTypes.func.isRequired,

--- a/app/widgets/Drawing/index.js
+++ b/app/widgets/Drawing/index.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { View, Text, StyleSheet } from 'react-native';
+import DrawingBoard from './DrawingBoard';
+
+const styles = StyleSheet.create({
+  text: {
+    paddingTop: 20,
+    paddingBottom: 20,
+  }
+});
+
+export class Drawing extends React.Component {
+  componentDidUpdate() {
+    const { value } = this.props;
+    if (!value.lines || value.lines.length === 0) {
+      this.board.reset();
+    }
+  }
+
+  render() {
+    const { config, value, onChange } = this.props;
+    return (
+      <View>
+        <DrawingBoard
+          sourceFiles={config.mode === 'picture' && config.pictureFiles}
+          autoStart
+          lines={value && value.lines}
+          onResult={onChange}
+          ref={(ref) => { this.board = ref; }}
+        />
+        {config.instruction && (
+          <Text style={styles.text}>{config.instruction}</Text>
+        )}
+      </View>
+    );
+  }
+}
+
+Drawing.defaultProps = {
+  config: {
+    mode: 'FREE_DRAW',
+  },
+  value: {},
+};
+
+Drawing.propTypes = {
+  config: PropTypes.shape({
+    mode: PropTypes.string,
+  }),
+  value: PropTypes.object,
+  onChange: PropTypes.func.isRequired,
+};

--- a/app/widgets/index.js
+++ b/app/widgets/index.js
@@ -2,6 +2,7 @@ export * from './audio-widgets/AudioImageRecord';
 export * from './audio-widgets/AudioRecord';
 export * from './audio-widgets/AudioStimulus';
 export * from './DatePicker';
+export * from './Drawing';
 export * from './MultiSelect';
 export * from './Radio';
 export * from './Select';


### PR DESCRIPTION
 - Adds a link on the applet list to join the "MindLogger Demo" applet
 - The MindLogger Demo applet contains an activity with each of the supported widgets, together with descriptions. Currently points to a schema on a branch on my fork (https://github.com/stufreen/schema-standardization/tree/widget-demo-activity) but that should be updated once the schema is merged into the main schema repo.
 - Cleans up the code for the drawing widget and makes some minor improvements

![image](https://user-images.githubusercontent.com/14841718/58724828-968d4e00-83ab-11e9-9e49-9a9964680b8e.png)

![image](https://user-images.githubusercontent.com/14841718/58724850-a311a680-83ab-11e9-9af4-fe707103b778.png)

