### PR TITLE
More Robust About Logic

### DIFF
--- a/app/scenes/AboutApp/index.js
+++ b/app/scenes/AboutApp/index.js
@@ -19,8 +19,7 @@ class AboutApp extends Component { // eslint-disable-line
     render() {
       const { skin } = this.props;
       const title = skin ? skin.name : 'MindLogger';
-
-      if (typeof skin.about !== 'undefined') {
+      if (typeof skin.about === 'string') {
         if (skin.about.replace(/\s/g, '').length) {
           return (
             <Container style={styles.container}>


### PR DESCRIPTION
- Only render custom about screen if the skin's ```about``` field is a string.
- Fixes https://github.com/ChildMindInstitute/mindlogger-app/issues/206 and renders the default about screen when an array is passed in the skin's ```about``` field.