### PR TITLE
Fix scrollview bug for Drawing and Slider

### DIFF
--- a/app/components/screen/index.js
+++ b/app/components/screen/index.js
@@ -45,6 +45,13 @@ class Screen extends Component {
     return (answer !== null && typeof answer !== 'undefined');
   }
 
+  constructor() {
+    super();
+    this.state = {
+      scrollEnabled: true,
+    };
+  }
+
   renderWidget() {
     const { screen, answer, onChange, isCurrent } = this.props;
     /*
@@ -88,6 +95,8 @@ class Screen extends Component {
         <Slider
           config={screen.valueConstraints}
           onChange={onChange}
+          onPress={() => this.setState({ scrollEnabled: false })}
+          onRelease={() => this.setState({ scrollEnabled: true })}
           value={answer}
         />
       );
@@ -169,6 +178,8 @@ class Screen extends Component {
         <Drawing
           config={screen.inputs}
           onChange={onChange}
+          onPress={() => this.setState({ scrollEnabled: false })}
+          onRelease={() => this.setState({ scrollEnabled: true })}
           value={answer}
         />
       );
@@ -181,11 +192,13 @@ class Screen extends Component {
 
   render() {
     const { screen } = this.props;
+    const { scrollEnabled } = this.state;
     return (
       <ScrollView
         alwaysBounceVertical={false}
         style={styles.paddingContent}
         contentContainerStyle={{ paddingBottom: 20, minHeight: '100%' }}
+        scrollEnabled={scrollEnabled}
       >
         <ScreenDisplay screen={screen} />
         {this.renderWidget()}

--- a/app/widgets/Drawing/index.js
+++ b/app/widgets/Drawing/index.js
@@ -11,15 +11,15 @@ const styles = StyleSheet.create({
 });
 
 export class Drawing extends React.Component {
-  componentDidUpdate() {
+  componentDidUpdate(oldProps) {
     const { value } = this.props;
-    if (!value.lines || value.lines.length === 0) {
+    if (value !== oldProps.value && !value.lines) {
       this.board.reset();
     }
   }
 
   render() {
-    const { config, value, onChange } = this.props;
+    const { config, value, onChange, onPress, onRelease } = this.props;
     return (
       <View>
         <DrawingBoard
@@ -27,6 +27,8 @@ export class Drawing extends React.Component {
           lines={value && value.lines}
           onResult={onChange}
           ref={(ref) => { this.board = ref; }}
+          onPress={onPress}
+          onRelease={onRelease}
         />
         {config.instruction && (
           <Text style={styles.text}>{config.instruction}</Text>
@@ -39,6 +41,8 @@ export class Drawing extends React.Component {
 Drawing.defaultProps = {
   config: {},
   value: {},
+  onPress: () => {},
+  onRelease: () => {},
 };
 
 Drawing.propTypes = {
@@ -47,4 +51,6 @@ Drawing.propTypes = {
   }),
   value: PropTypes.object,
   onChange: PropTypes.func.isRequired,
+  onPress: PropTypes.func,
+  onRelease: PropTypes.func,
 };

--- a/app/widgets/Slider/index.js
+++ b/app/widgets/Slider/index.js
@@ -7,7 +7,13 @@ import SliderComponent from './slider';
 import { getURL } from '../../services/helper';
 
 
-export const Slider = ({ config: { maxValue, minValue, itemList }, value, onChange }) => (
+export const Slider = ({
+  config: { maxValue, minValue, itemList },
+  value,
+  onChange,
+  onPress,
+  onRelease,
+}) => (
   <View style={{ alignItems: 'stretch', minHeight: 450 }}>
     <Text style={{ textAlign: 'center' }}>{maxValue}</Text>
     { itemList[itemList.length-1].image ? <View style={{justifyContent: 'center', alignItems: 'center'}}><CachedImage style={{ width: 45, height: 45, resizeMode: 'cover' }} source={{ uri: getURL(itemList[itemList.length-1].image.en) }} /></View> : <View></View>}
@@ -20,6 +26,8 @@ export const Slider = ({ config: { maxValue, minValue, itemList }, value, onChan
       barHeight={200}
       selected={!!value}
       onChange={onChange}
+      onPress={onPress}
+      onRelease={onRelease}
     />
     { itemList[0].image ? <View style={{justifyContent: 'center', alignItems: 'center'}}><CachedImage style={{ width: 45, height: 45, resizeMode: 'cover' }} source={{ uri: getURL(itemList[0].image.en) }} /></View> : <View></View>}
     <Text style={{ textAlign: 'center' }}>{minValue}</Text>
@@ -28,6 +36,8 @@ export const Slider = ({ config: { maxValue, minValue, itemList }, value, onChan
 
 Slider.defaultProps = {
   value: undefined,
+  onPress: () => {},
+  onRelease: () => { },
 };
 
 Slider.propTypes = {
@@ -38,4 +48,6 @@ Slider.propTypes = {
   }).isRequired,
   value: PropTypes.number,
   onChange: PropTypes.func.isRequired,
+  onPress: PropTypes.func,
+  onRelease: PropTypes.func,
 };

--- a/app/widgets/Slider/slider.js
+++ b/app/widgets/Slider/slider.js
@@ -13,26 +13,31 @@ export default class Slider extends React.Component {
     min: PropTypes.number.isRequired,
     max: PropTypes.number.isRequired,
     labels: PropTypes.array,
-    strict: PropTypes.bool
+    strict: PropTypes.bool,
+    value: PropTypes.number.isRequired,
   }
 
-  state = {
-    barHeight: 200,
-    deltaValue: 0,
-    value: 0,
-  };
-
-  componentWillMount() {
-    this.setState({ value: this.props.value });
-
+  constructor(props) {
+    super(props);
+    this.state = {
+      barHeight: 200,
+      deltaValue: 0,
+      value: this.props.value,
+    };
+    this.panResponder = PanResponder.create({
+      onStartShouldSetPanResponder: (evt, gestureState) => {
+        this.props.onPress();
+        return true;
+      },
+      onPanResponderMove: (evt, gestureState) => {
+        return this.onMove(gestureState);
+      },
+      onPanResponderRelease: (evt, gestureState) => {
+        this.onEndMove();
+        this.props.onRelease();
+      },
+    });
   }
-
-  panResponder = PanResponder.create({
-    onMoveShouldSetPanResponderCapture: () => true,
-    onPanResponderMove: (_, gestureState) => this.onMove(gestureState),
-    onPanResponderRelease: () => this.onEndMove(),
-    onPanResponderTerminate: () => { }
-  });
 
   onMove(gestureState) {
     const { barHeight } = this.state;


### PR DESCRIPTION
The Drawing and Slider widgets, that use the `PanResponder` API, were encountering a bug when they were nested inside a `ScrollView`. The `ScrollView` would cancel all touch events being sent to the widgets.

The solution was to disable scrolling on the `ScrollView` while the widgets are being interacted with.

This PR also fixes a bug with the Slider widget to give it an initial value.