### PR TITLE
Feat/screen control

### DIFF
--- a/app/components/screen/ScreenButton.js
+++ b/app/components/screen/ScreenButton.js
@@ -20,7 +20,11 @@ const ScreenButton = ({ transparent = false, onPress, text, children }) => {
         {children}
       </Button>
     )
-    : <View style={styles.button} />;
+    : (
+      <Button transparent style={styles.button}>
+        <Text style={styles.buttonText}> </Text>
+      </Button>
+    );
 };
 
 export default ScreenButton;

--- a/app/models/__tests__/json-ld.test.js
+++ b/app/models/__tests__/json-ld.test.js
@@ -153,8 +153,7 @@ test('activityTransformJson: ema-hbn', () => {
     shuffle: false,
     scoringLogic: [],
     altLabel: { en: 'ema_morning_schema' },
-    allowDoNotKnow: false,
-    allowRefuseToAnswer: false,
+    skippable: false,
     info: undefined,
     notification: {},
   };
@@ -182,8 +181,7 @@ test('activityTransformJson: nda-phq', () => {
   });
 
   const expectedResult = {
-    allowDoNotKnow: false,
-    allowRefuseToAnswer: true,
+    skippable: true,
     altLabel: { en: 'nda_guid' },
     description: {
       en: 'schema describing terms needed to generate NDA guid',

--- a/app/models/__tests__/json-ld.test.js
+++ b/app/models/__tests__/json-ld.test.js
@@ -154,6 +154,9 @@ test('activityTransformJson: ema-hbn', () => {
     scoringLogic: [],
     altLabel: { en: 'ema_morning_schema' },
     skippable: false,
+    autoAdvance: false,
+    backDisabled: false,
+    fullScreen: false,
     info: undefined,
     notification: {},
   };
@@ -182,6 +185,9 @@ test('activityTransformJson: nda-phq', () => {
 
   const expectedResult = {
     skippable: true,
+    autoAdvance: false,
+    backDisabled: false,
+    fullScreen: false,
     altLabel: { en: 'nda_guid' },
     description: {
       en: 'schema describing terms needed to generate NDA guid',
@@ -244,6 +250,10 @@ test('itemTransformJson', () => {
         },
       ],
     },
+    skippable: undefined,
+    autoAdvance: false,
+    backDisabled: false,
+    fullScreen: false,
   });
 });
 

--- a/app/models/json-ld.js
+++ b/app/models/json-ld.js
@@ -153,10 +153,8 @@ export const appletTransformJson = appletJson => ({
 
 export const itemTransformJson = (itemJson) => {
   // For items, 'skippable' is undefined if there's no ALLOW prop
-  const allowList = R.path([ALLOW, 0, '@list'], itemJson);
-  const skippable = typeof allowList === 'undefined'
-    ? undefined
-    : isSkippable(flattenIdList(allowList));
+  const allowList = flattenIdList(R.path([ALLOW, 0, '@list'], itemJson));
+  const skippable = isSkippable(allowList) ? true : undefined;
 
   const valueConstraintsObj = R.pathOr({}, [VALUE_CONSTRAINTS, 0], itemJson);
   const valueConstraints = flattenValueConstraints(valueConstraintsObj);
@@ -165,7 +163,6 @@ export const itemTransformJson = (itemJson) => {
   const inputsObj = transformInputs(inputs);
 
   return {
-    name: languageListToObject(itemJson[PREF_LABEL]),
     description: languageListToObject(itemJson[DESCRIPTION]),
     schemaVersion: languageListToObject(itemJson[SCHEMA_VERSION]),
     version: languageListToObject(itemJson[VERSION]),
@@ -175,9 +172,9 @@ export const itemTransformJson = (itemJson) => {
     preamble: languageListToObject(itemJson[PREAMBLE]),
     valueConstraints,
     skippable,
-    fullScreen: flattenIdList(allowList).includes(FULL_SCREEN),
-    backDisabled: flattenIdList(allowList).includes(BACK_DISABLED),
-    autoAdvance: flattenIdList(allowList).includes(AUTO_ADVANCE),
+    fullScreen: allowList.includes(FULL_SCREEN),
+    backDisabled: allowList.includes(BACK_DISABLED),
+    autoAdvance: allowList.includes(AUTO_ADVANCE),
     inputs: inputsObj,
   };
 };

--- a/app/models/json-ld.js
+++ b/app/models/json-ld.js
@@ -3,9 +3,12 @@ import * as R from 'ramda';
 const ALLOW = 'https://schema.repronim.org/allow';
 const ALT_LABEL = 'http://www.w3.org/2004/02/skos/core#altLabel';
 const AUDIO_OBJECT = 'http://schema.org/AudioObject';
+const AUTO_ADVANCE = 'https://schema.repronim.org/auto_advance';
+const BACK_DISABLED = 'https://schema.repronim.org/disable_back';
 const CONTENT_URL = 'http://schema.org/contentUrl';
 const DESCRIPTION = 'http://schema.org/description';
 const DO_NOT_KNOW = 'https://schema.repronim.org/dont_know_answer';
+const FULL_SCREEN = 'https://schema.repronim.org/full_screen';
 const IMAGE = 'http://schema.org/image';
 const IMAGE_OBJECT = 'http://schema.org/ImageObject';
 const INPUT_TYPE = 'https://schema.repronim.org/inputType';
@@ -172,6 +175,9 @@ export const itemTransformJson = (itemJson) => {
     preamble: languageListToObject(itemJson[PREAMBLE]),
     valueConstraints,
     skippable,
+    fullScreen: flattenIdList(allowList).includes(FULL_SCREEN),
+    backDisabled: flattenIdList(allowList).includes(BACK_DISABLED),
+    autoAdvance: flattenIdList(allowList).includes(AUTO_ADVANCE),
     inputs: inputsObj,
   };
 };
@@ -216,6 +222,9 @@ export const activityTransformJson = (activityJson, itemsJson) => {
     shuffle: R.path([SHUFFLE, 0, '@value'], activityJson),
     image: languageListToObject(activityJson[IMAGE]),
     skippable: isSkippable(allowList),
+    backDisabled: allowList.includes(BACK_DISABLED),
+    fullScreen: allowList.includes(FULL_SCREEN),
+    autoAdvance: allowList.includes(AUTO_ADVANCE),
     scoringLogic,
     notification,
     info,

--- a/app/scenes/Activity/index.js
+++ b/app/scenes/Activity/index.js
@@ -24,6 +24,7 @@ import {
   getPrevLabel,
   getActionLabel,
   isNextEnabled,
+  isPrevEnabled,
 } from '../../services/activityNavigation';
 
 const styles = StyleSheet.create({
@@ -49,13 +50,10 @@ const Activity = ({
   if (!currentResponse) {
     return <View />;
   }
-
   const { activity, responses } = currentResponse;
-
-  // Hide the header and footer if it's a certain type of widget
   const currentItem = R.path(['items', currentScreen], activity);
-  const inputType = R.path(['inputType'], currentItem);
-  const fullScreen = inputType === 'visual-stimulus-response';
+  const fullScreen = currentItem.fullScreen || activity.fullScreen;
+  const autoAdvance = currentItem.autoAdvance || activity.autoAdvance;
 
   return (
     <Container>
@@ -67,15 +65,7 @@ const Activity = ({
         currentScreen={currentScreen}
         onChange={(answer) => {
           setAnswer(activity.id, currentScreen, answer);
-          if (inputType === 'visual-stimulus-response'
-            || inputType === 'slider') {
-            nextScreen();
-          }
-          if (inputType === 'radio'
-            && R.path(['valueConstraints', 'multipleChoice'], currentItem) !== true) {
-            nextScreen();
-          }
-          if (inputType === 'audioStimulus' && R.path(['inputs', 'autoAdvance'], currentItem)) {
+          if (autoAdvance || fullScreen) {
             nextScreen();
           }
         }}
@@ -91,7 +81,7 @@ const Activity = ({
             nextEnabled={isNextEnabled(currentScreen, activity, responses)}
             onPressNext={nextScreen}
             prevLabel={getPrevLabel(currentScreen, itemVisibility)}
-            prevEnabled
+            prevEnabled={isPrevEnabled(currentScreen, activity)}
             onPressPrev={prevScreen}
             actionLabel={getActionLabel(currentScreen, responses, activity.items)}
             onPressAction={() => { setAnswer(activity.id, currentScreen, undefined); }}

--- a/app/services/activityNavigation.js
+++ b/app/services/activityNavigation.js
@@ -9,8 +9,15 @@ const UNDO = 'Undo';
 
 export const checkValidity = (item, response) => Screen.isValid(response, item);
 
-export const checkSkippable = activity => activity.allowRefuseToAnswer === true
-  || activity.allowDoNotKnow === true;
+export const checkSkippable = (activity, item) => {
+  if (typeof item.skippable !== 'undefined') {
+    return item.skippable;
+  }
+  if (activity.skippable === true) {
+    return true;
+  }
+  return false;
+};
 
 // Gets the next position of array after index that is true, or -1
 export const getNextPos = (index, ar) => {
@@ -55,8 +62,18 @@ export const getNextLabel = (index, visibility, activity, responses) => {
 // If item has a valid response, or is skippable, then next is enabled
 export const isNextEnabled = (index, activity, responses) => {
   const isValid = checkValidity(activity.items[index], responses[index]);
-  const isSkippable = checkSkippable(activity);
+  const isSkippable = checkSkippable(activity, activity.items[index]);
   return isValid || isSkippable;
+};
+
+export const isPrevEnabled = (index, activity) => {
+  if (activity.items[index].backDisabled === true) {
+    return false;
+  }
+  if (activity.backDisabled === true) {
+    return false;
+  }
+  return true;
 };
 
 export const getPrevLabel = (index, visibility) => {

--- a/app/services/activityNavigation.test.js
+++ b/app/services/activityNavigation.test.js
@@ -7,23 +7,34 @@ import {
 
 jest.mock('../components/screen', () => {});
 
-test('checkSkippable considers allowRefuseToAnswer to be skippable', () => {
+test('checkSkippable defaults to activity', () => {
   const activity = {
-    allowRefuseToAnswer: true,
+    skippable: true,
   };
-  expect(checkSkippable(activity)).toBe(true);
+  const item = {
+    skippable: undefined,
+  };
+  expect(checkSkippable(activity, item)).toBe(true);
 });
 
-test('checkSkippable considers allowDoNotKnow to be skippable', () => {
+test('checkSkippable prefers item skippable', () => {
   const activity = {
-    allowDoNotKnow: true,
+    skippable: false,
   };
-  expect(checkSkippable(activity)).toBe(true);
+  const item = {
+    skippable: true,
+  };
+  expect(checkSkippable(activity, item)).toBe(true);
 });
 
 test('checkSkippable returns false if neither are present', () => {
-  const activity = {};
-  expect(checkSkippable(activity)).toBe(false);
+  const activity = {
+    skippable: false,
+  };
+  const item = {
+    skippable: undefined,
+  };
+  expect(checkSkippable(activity, item)).toBe(false);
 });
 
 test('getNextPos returns the next index', () => {

--- a/app/state/app/app.reducer.test.js
+++ b/app/state/app/app.reducer.test.js
@@ -48,8 +48,8 @@ test('it sets current activity', () => {
 });
 
 test('it turns mobile data on and off', () => {
-  expect(appReducer(initialState, toggleMobileDataAllowed().toEqual({
+  expect(appReducer(initialState, toggleMobileDataAllowed())).toEqual({
     ...initialState,
     mobileDataAllowed: !initialState.mobileDataAllowed,
-  })))
-})
+  });
+});

--- a/app/themes/activityTheme.js
+++ b/app/themes/activityTheme.js
@@ -1,6 +1,6 @@
 import { StyleSheet } from 'react-native';
 
-export default styles = StyleSheet.create({
+const styles = StyleSheet.create({
   body: {
     flex: 1,
   },
@@ -20,7 +20,7 @@ export default styles = StyleSheet.create({
   },
   buttonText: {
     fontSize: 24,
-    fontWeight: '300'
+    fontWeight: '300',
   },
   takeButton: {
     borderRadius: 12,
@@ -31,7 +31,7 @@ export default styles = StyleSheet.create({
     alignItems: 'center',
     borderWidth: 4,
     borderColor: '#d10000',
-    backgroundColor: '#ffdddd'
+    backgroundColor: '#ffdddd',
   },
   videoConfirmed: {
     borderRadius: 12,
@@ -42,7 +42,7 @@ export default styles = StyleSheet.create({
     alignItems: 'center',
     borderWidth: 4,
     borderColor: '#00a30a',
-    backgroundColor: '#99ff9f'
+    backgroundColor: '#99ff9f',
   },
   chooseButton: {
     borderRadius: 12,
@@ -63,7 +63,7 @@ export default styles = StyleSheet.create({
   greenIcon: {
     color: '#00a30a',
     fontSize: 60,
-  }
+  },
 });
 
 export const markdownStyle = {
@@ -89,9 +89,11 @@ export const markdownStyle = {
   },
   listItemUnorderedContent: {
     fontSize: 18,
+    color: '#000000',
   },
   listItemOrderedContent: {
     fontSize: 18,
+    color: '#000000',
   },
   linkWrapper: {
     alignSelf: 'flex-start',
@@ -104,3 +106,5 @@ export const markdownStyle = {
     resizeMode: 'contain',
   },
 };
+
+export default styles;

--- a/app/widgets/Camera.js
+++ b/app/widgets/Camera.js
@@ -17,10 +17,11 @@ export class Camera extends Component {
         waitUntilSaved: true,
       },
       quality: 0.5,
-      cameraType: 'front',
+      cameraType: 'back',
       videoQuality: 'low',
       maxWidth: 2048,
       maxHeight: 2048,
+      chooseFromLibraryButtonTitle: 'Library',
     };
     ImagePicker.launchCamera(options, (response) => {
       if (!response.didCancel && !response.error) {


### PR DESCRIPTION
 * Implements the ability to set skip, full screen, auto advance, and disable back at the item or activity level in the schemas
 * If no value is set for an item, it will default to the activity value. If no item AND not activity value is set, it will default to `false` for each
 * Fixes some small issues with the Camera widget