### PR TITLE
Add timer and delay

### DIFF
--- a/app/components/ActivityScreens.js
+++ b/app/components/ActivityScreens.js
@@ -36,7 +36,7 @@ const ActivityScreens = ({
           <Screen
             screen={item}
             answer={answers[index]}
-            onChange={(answer) => { onChange(answer, index); }}
+            onChange={onChange}
             authToken={authToken}
             isCurrent={index === currentScreen}
           />

--- a/app/components/Clock.js
+++ b/app/components/Clock.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Svg, Circle } from 'react-native-svg';
+
+class Clock extends React.Component {
+  render() {
+    const { percentComplete, color, size, strokeWidth } = this.props;
+    return (
+      <Svg
+        height={size}
+        width={size}
+      >
+        <Circle
+          cx={size / 2}
+          cy={size / 2}
+          r={(size - strokeWidth) / 2}
+          fill="transparent"
+          stroke="rgba(0, 0, 0, 0.1)"
+          strokeWidth={strokeWidth}
+        />
+        <Circle
+          rotation={-90}
+          originX={size / 2}
+          originY={size / 2}
+          cx={size / 2}
+          cy={size / 2}
+          r={(size - strokeWidth) / 2}
+          fill="transparent"
+          stroke={color}
+          strokeWidth={strokeWidth}
+          strokeDashoffset={Math.PI * (size - strokeWidth) * (1 - percentComplete)}
+          strokeDasharray={Math.PI * (size - strokeWidth)}
+        />
+      </Svg>
+    )
+  }
+}
+
+Clock.defaultProps = {
+  percentComplete: 0,
+  color: '#333333',
+  size: 60,
+  strokeWidth: 10,
+};
+
+Clock.propTypes = {
+  percentComplete: PropTypes.number,
+  color: PropTypes.string,
+  size: PropTypes.number,
+  strokeWidth: PropTypes.number,
+};
+
+export default Clock;

--- a/app/components/Timer.js
+++ b/app/components/Timer.js
@@ -1,0 +1,62 @@
+import React from 'react';
+import { Animated, Easing } from 'react-native';
+import PropTypes from 'prop-types';
+import Clock from './Clock';
+
+const AnimatedClock = Animated.createAnimatedComponent(Clock);
+
+class Timer extends React.Component {
+  state = {
+    timeline: new Animated.Value(0),
+  }
+
+  componentDidMount() {
+    this.start();
+  }
+
+  stop = () => {
+    const { timeline } = this.state;
+    timeline.stopAnimation();
+    timeline.setValue(0);
+  }
+
+  start = () => {
+    const { duration } = this.props;
+    Animated.timing(
+      this.state.timeline,
+      {
+        toValue: 1,
+        duration,
+        easing: Easing.linear,
+      },
+    ).start();
+  }
+
+  render() {
+    const { size, strokeWidth, color } = this.props;
+    const { timeline } = this.state;
+    return (
+      <AnimatedClock
+        size={size}
+        strokeWidth={strokeWidth || (size / 2)}
+        color={color}
+        percentComplete={timeline}
+      />
+    );
+  }
+}
+
+Timer.defaultProps = {
+  size: 100,
+  strokeWidth: undefined,
+  color: '#303030',
+};
+
+Timer.propTypes = {
+  size: PropTypes.number,
+  strokeWidth: PropTypes.number,
+  color: PropTypes.string,
+  duration: PropTypes.number.isRequired,
+};
+
+export default Timer;

--- a/app/components/screen/Widget.js
+++ b/app/components/screen/Widget.js
@@ -1,0 +1,194 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import * as R from 'ramda';
+import WidgetError from './WidgetError';
+import {
+  AudioImageRecord,
+  AudioRecord,
+  AudioStimulus,
+  DatePicker,
+  MultiSelect,
+  Radio,
+  Select,
+  Slider,
+  TextEntry,
+  TimeRange,
+  VisualStimulusResponse,
+  Drawing,
+  Camera,
+  TableInput,
+} from '../../widgets';
+
+const Widget = ({ screen, answer, onChange, isCurrent, onPress, onRelease }) => {
+  if (screen.inputType === 'radio'
+    && R.path(['valueConstraints', 'multipleChoice'], screen) === true) {
+    return (
+      <MultiSelect
+        config={screen.valueConstraints}
+        onChange={onChange}
+        value={answer}
+      />
+    );
+  }
+  if (screen.inputType === 'radio'
+    && R.path(['valueConstraints', 'itemList'], screen)) {
+    return (
+      <Radio
+        config={screen.valueConstraints}
+        onChange={onChange}
+        value={answer}
+      />
+    );
+  }
+  if (screen.inputType === 'slider') {
+    return (
+      <Slider
+        config={screen.valueConstraints}
+        onChange={onChange}
+        onPress={onPress}
+        onRelease={onRelease}
+        value={answer}
+      />
+    );
+  }
+  if (screen.inputType === 'timeRange') {
+    return (
+      <TimeRange
+        onChange={onChange}
+        value={answer}
+      />
+    );
+  }
+  if (screen.inputType === 'date') {
+    return (
+      <DatePicker
+        onChange={onChange}
+        value={answer}
+      />
+    );
+  }
+  if (screen.inputType === 'select'
+    && R.path(['valueConstraints', 'itemList'], screen)) {
+    return (
+      <Select
+        onChange={onChange}
+        value={answer}
+        config={screen.valueConstraints}
+      />
+    );
+  }
+  if (screen.inputType === 'text') {
+    return (
+      <TextEntry
+        onChange={onChange}
+        value={answer}
+      />
+    );
+  }
+  if (screen.inputType === 'audioRecord' || screen.inputType === 'audioPassageRecord') {
+    return (
+      <AudioRecord
+        onChange={onChange}
+        config={screen.valueConstraints}
+        value={answer}
+      />
+    );
+  }
+  if (screen.inputType === 'audioImageRecord'
+    && R.path(['valueConstraints', 'image'], screen)) {
+    return (
+      <AudioImageRecord
+        onChange={onChange}
+        config={screen.valueConstraints}
+        value={answer}
+      />
+    );
+  }
+  if (screen.inputType === 'audioStimulus') {
+    return (
+      <AudioStimulus
+        value={answer}
+        onChange={onChange}
+        config={screen.inputs}
+        isCurrent={isCurrent}
+      />
+    );
+  }
+  if (screen.inputType === 'photo') {
+    return (
+      <Camera
+        value={answer}
+        onChange={onChange}
+      />
+    );
+  }
+  if (screen.inputType === 'video') {
+    return (
+      <Camera
+        value={answer}
+        onChange={onChange}
+        video
+      />
+    );
+  }
+  if (screen.inputType === 'visual-stimulus-response') {
+    return (
+      <VisualStimulusResponse
+        onChange={onChange}
+        config={screen.inputs}
+        isCurrent={isCurrent}
+      />
+    );
+  }
+  if (screen.inputType === 'drawing') {
+    return (
+      <Drawing
+        config={screen.inputs}
+        onChange={onChange}
+        onPress={onPress}
+        onRelease={onRelease}
+        value={answer}
+      />
+    );
+  }
+  if (screen.inputType === 'tableCounter') {
+    return (
+      <TableInput
+        config={screen.inputs}
+        onChange={onChange}
+        value={answer}
+      />
+    );
+  }
+  if (screen.inputType === 'tableText') {
+    return (
+      <TableInput
+        config={screen.inputs}
+        onChange={onChange}
+        value={answer}
+        freeEntry
+      />
+    );
+  }
+  if (screen.inputType === 'markdown-message') {
+    return null;
+  }
+  return <WidgetError />;
+};
+
+Widget.defaultProps = {
+  answer: undefined,
+  onPress: () => {},
+  onRelease: () => {},
+};
+
+Widget.propTypes = {
+  screen: PropTypes.object.isRequired,
+  answer: PropTypes.any,
+  onChange: PropTypes.func.isRequired,
+  isCurrent: PropTypes.bool.isRequired,
+  onPress: PropTypes.func,
+  onRelease: PropTypes.func,
+};
+
+export default Widget;

--- a/app/models/json-ld.js
+++ b/app/models/json-ld.js
@@ -6,6 +6,7 @@ const AUDIO_OBJECT = 'http://schema.org/AudioObject';
 const AUTO_ADVANCE = 'https://schema.repronim.org/auto_advance';
 const BACK_DISABLED = 'https://schema.repronim.org/disable_back';
 const CONTENT_URL = 'http://schema.org/contentUrl';
+const DELAY = 'https://schema.repronim.org/delay';
 const DESCRIPTION = 'http://schema.org/description';
 const DO_NOT_KNOW = 'https://schema.repronim.org/dont_know_answer';
 const FULL_SCREEN = 'https://schema.repronim.org/full_screen';
@@ -28,6 +29,7 @@ const REQUIRED_VALUE = 'http://schema.repronim.org/requiredValue';
 const SCHEMA_VERSION = 'http://schema.org/schemaVersion';
 const SCORING_LOGIC = 'https://schema.repronim.org/scoringLogic';
 const SHUFFLE = 'https://schema.repronim.org/shuffle';
+const TIMER = 'https://schema.repronim.org/timer';
 const TRANSCRIPT = 'http://schema.org/transcript';
 const URL = 'http://schema.org/url';
 const VALUE = 'http://schema.org/value';
@@ -170,6 +172,8 @@ export const itemTransformJson = (itemJson) => {
     inputType: listToValue(itemJson[INPUT_TYPE]),
     question: languageListToObject(itemJson[QUESTION]),
     preamble: languageListToObject(itemJson[PREAMBLE]),
+    timer: R.path([TIMER, 0, '@value'], itemJson),
+    delay: R.path([DELAY, 0, '@value'], itemJson),
     valueConstraints,
     skippable,
     fullScreen: allowList.includes(FULL_SCREEN),

--- a/app/scenes/Activity/index.js
+++ b/app/scenes/Activity/index.js
@@ -63,9 +63,9 @@ const Activity = ({
         activity={activity}
         answers={responses}
         currentScreen={currentScreen}
-        onChange={(answer) => {
+        onChange={(answer, goToNext = false) => {
           setAnswer(activity.id, currentScreen, answer);
-          if (autoAdvance || fullScreen) {
+          if (goToNext || autoAdvance || fullScreen) {
             nextScreen();
           }
         }}

--- a/app/widgets/AudioRecord/AudioImageRecord.js
+++ b/app/widgets/AudioRecord/AudioImageRecord.js
@@ -16,7 +16,6 @@ export class AudioImageRecord extends Component {
         <Image
           style={{ width: '100%', height: 260, resizeMode: 'contain', marginBottom: 16 }}
           source={{ uri: config.image.en }}
-          loadingIndicatorSource
         />
         <AudioRecorder
           onStop={this.onRecord}

--- a/app/widgets/AudioRecord/AudioRecorder.js
+++ b/app/widgets/AudioRecord/AudioRecorder.js
@@ -44,6 +44,10 @@ export default class AudioRecorder extends Component {
     if (recorder) {
       recorder.destroy();
     }
+    if (intervalId) {
+      clearInterval(intervalId);
+      intervalId = null;
+    }
   }
 
   record = () => {
@@ -119,6 +123,7 @@ export default class AudioRecorder extends Component {
           console.warn(err, message);
         }
         clearInterval(intervalId);
+        intervalId = null;
         this.setState({
           recorderState: 'stopped',
         });
@@ -138,6 +143,7 @@ export default class AudioRecorder extends Component {
       });
     }
     clearInterval(intervalId);
+    intervalId = null;
     this.setState({
       recorderState: 'ready',
       elapsed: null,


### PR DESCRIPTION
Each item can now have a `timer` or `delay` property in its schema, nested in the `ui` property. Each should be a number (milliseconds).

Adding a `delay` will cause the widget to be semi-transparent for a period of time and the user cannot enter a response while the delay is ongoing.

Adding a `timer` will add a time limit to the screen. When the timer elapses it will automatically advance to the next screen, using the current answer.

These features can be tested in the MindLoggerDemo activity on the final two screens.

![image](https://user-images.githubusercontent.com/14841718/59132500-5c8bf100-8943-11e9-9f1e-896f9db13932.png)

![image](https://user-images.githubusercontent.com/14841718/59132514-64e42c00-8943-11e9-8c8a-cd8ee8e2c3f4.png)



