### PR TITLE
fix: dot for today only shows up if there was a response today.

### DIFF
--- a/app/scenes/AppletDetails/AppletDetailsComponent.js
+++ b/app/scenes/AppletDetails/AppletDetailsComponent.js
@@ -41,6 +41,7 @@ class AppletDetailsComponent extends React.Component {
     // if the user has responded today. This is instead of
     // refreshing all the applets
     const { applet, appletData } = this.props;
+    console.log('appletData in responseDates', appletData);
     let allDates = [];
     const mapper = (resp) => {
       const d = resp.map(r => r.date);
@@ -51,10 +52,12 @@ class AppletDetailsComponent extends React.Component {
     const items = Object.keys(appletData.responses);
     items.map(item => mapper(appletData.responses[item]));
 
-    const maxDate = moment.max(allDates.map(d => moment(d)));
+    if (allDates.length) {
+      const maxDate = moment.max(allDates.map(d => moment(d)));
 
-    if (applet.responseDates.indexOf(maxDate) < 0) {
-      applet.responseDates.push(maxDate);
+      if (applet.responseDates.indexOf(maxDate) < 0) {
+        applet.responseDates.push(maxDate);
+      }
     }
 
     return applet.responseDates;

--- a/app/widgets/Slider/index.js
+++ b/app/widgets/Slider/index.js
@@ -18,6 +18,9 @@ export const Slider = ({
     { itemList[itemList.length - 1].image ? <View style={{ justifyContent: 'center', alignItems: 'center' }}><Image style={{ width: 45, height: 45, resizeMode: 'cover' }} source={{ uri: getURL(itemList[itemList.length - 1].image.en) }} /></View> : <View />}
     <SliderComponent
       value={value || 0}
+      /**
+       * TODO: min and max below don't respect the schema's min and max
+       */
       min={1}
       max={itemList.length || 100}
       labels={itemList.map(item => ({ text: item.name.en }))}


### PR DESCRIPTION
I noticed there is a dot on the current day's calendar even when the user hasn't submitted any responses for the current day. That's because `moment.max([])` returns today (weird). Anywho, this is fixed with this PR, and also includes a warning about the slider widget referenced here: https://github.com/ChildMindInstitute/mindlogger-app/issues/289