### PR TITLE
Fix schema handling for HBN EMA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 =======
+## [0.8.8] - 2019-11-12
+### Fixed
+- Schema handling for HBN EMA
+
 ## [0.8.7] - 2019-11-08
 ### Upgraded
 - :rocket: :apple: BitRise Deploy to iTunes Connect - Application Loader@0.10.1

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MindLogger 0.8.7
+# MindLogger 0.8.8
 
 _Note: v0.1 is deprecated as of June 12, 2019._
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -101,8 +101,8 @@ android {
         applicationId "lab.childmindinstitute.data"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 90
-        versionName "0.8.7"
+        versionCode 91
+        versionName "0.8.8"
         ndk {
             abiFilters "arm64-v8a", "x86_64", "armeabi-v7a", "x86"
         }

--- a/app/components/AppletImage.js
+++ b/app/components/AppletImage.js
@@ -18,11 +18,11 @@ const getURL = (url) => {
 
 const AppletImage = ({ applet, size = 64 }) => {
   // Display the image if there is one
-  if (typeof applet.image !== 'undefined' && applet.image.en) {
+  if (typeof applet.image !== 'undefined') {
     return (
       <CachedImage
         style={{ width: size, height: size, resizeMode: 'cover' }}
-        source={{ uri: getURL(applet.image.en) }}
+        source={{ uri: getURL(applet.image) }}
       />
     );
   }

--- a/app/components/AppletInvite.js
+++ b/app/components/AppletInvite.js
@@ -50,10 +50,8 @@ const AcceptAppletInvite = ({ invites, setCurrentInvite }) => (
           };
         }
 
-        if (image && !applet.image.en) {
-          applet.image = {
-            en: image,
-          };
+        if (image && !applet.image) {
+          applet.image = image;
         }
 
         return (

--- a/app/models/__tests__/ema-hbn.json
+++ b/app/models/__tests__/ema-hbn.json
@@ -18,19 +18,14 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNEvening/ema_evening_schema.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNEvening/ema_evening_schema.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
           "@value": "0.0.1"
         }
       ],
-      "http://schema.repronim.org/preamble": [
+      "reprolib:terms/preamble": [
         {
           "@language": "en",
           "@value": ""
@@ -132,19 +127,14 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNMorning/ema_morning_schema.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNMorning/ema_morning_schema.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
           "@value": "0.0.1"
         }
       ],
-      "http://schema.repronim.org/preamble": [
+      "reprolib:terms/preamble": [
         {
           "@language": "en",
           "@value": ""
@@ -210,7 +200,7 @@
     "responseDates": [],
     "schedule": {},
     "http://schema.org/about":[{"@language": "en", "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activity-sets/ema-hbn/README.md"}],
-    "http://schema.org/image": [{"@language": "en", "@value": "https://childmindinstitute.github.io/mindlogger-assets/illustrations/undraw/hbn_ema_image.svg"}],
+    "http://schema.org/image": "https://childmindinstitute.github.io/mindlogger-assets/illustrations/undraw/hbn_ema_image.svg",
     "http://schema.org/description": [
       {
         "@language": "en",
@@ -223,12 +213,7 @@
         "@value": "0.0.1"
       }
     ],
-    "http://schema.org/url": [
-      {
-        "@language": "en",
-        "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activity-sets/ema-hbn/ema-hbn_schema.jsonld"
-      }
-    ],
+    "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activity-sets/ema-hbn/ema-hbn_schema.jsonld",
     "http://schema.org/version": [
       {
         "@language": "en",
@@ -315,12 +300,7 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNEvening/items/energy.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNEvening/items/energy.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
@@ -354,12 +334,7 @@
             {
               "@list": [
                 {
-                  "http://schema.org/image": [
-                    {
-                      "@language": "en",
-                      "@value": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F634.svg?sanitize=true"
-                    }
-                  ],
+                  "http://schema.org/image": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F634.svg?sanitize=true",
                   "http://schema.org/name": [
                     {
                       "@language": "en",
@@ -412,12 +387,7 @@
                   ]
                 },
                 {
-                  "http://schema.org/image": [
-                    {
-                      "@language": "en",
-                      "@value": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F606.svg?sanitize=true"
-                    }
-                  ],
+                  "http://schema.org/image": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F606.svg?sanitize=true",
                   "http://schema.org/name": [
                     {
                       "@language": "en",
@@ -445,7 +415,7 @@
               "@value": "very tired"
             }
           ],
-          "http://schema.repronim.org/requiredValue": [
+          "reprolib:terms/required": [
             {
               "@type": "http://schema.org/Boolean",
               "@value": false
@@ -478,12 +448,7 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNEvening/items/enjoyed_day.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNEvening/items/enjoyed_day.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
@@ -517,12 +482,7 @@
             {
               "@list": [
                 {
-                  "http://schema.org/image": [
-                    {
-                      "@language": "en",
-                      "@value": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F621.svg?sanitize=true"
-                    }
-                  ],
+                  "http://schema.org/image": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F621.svg?sanitize=true",
                   "http://schema.org/name": [
                     {
                       "@language": "en",
@@ -588,12 +548,7 @@
                   ]
                 },
                 {
-                  "http://schema.org/image": [
-                    {
-                      "@language": "en",
-                      "@value": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F601.svg?sanitize=true"
-                    }
-                  ],
+                  "http://schema.org/image": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F601.svg?sanitize=true",
                   "http://schema.org/name": [
                     {
                       "@language": "en",
@@ -621,7 +576,7 @@
               "@value": "No enjoyment or pleasure"
             }
           ],
-          "http://schema.repronim.org/requiredValue": [
+          "reprolib:terms/required": [
             {
               "@type": "http://schema.org/Boolean",
               "@value": false
@@ -654,12 +609,7 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNEvening/items/good_bad_day.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNEvening/items/good_bad_day.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
@@ -696,12 +646,7 @@
                   "@type": [
                     "http://schema.org/Boolean"
                   ],
-                  "http://schema.org/image": [
-                    {
-                      "@language": "en",
-                      "@value": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F44E.svg?sanitize=true"
-                    }
-                  ],
+                  "http://schema.org/image": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F44E.svg?sanitize=true",
                   "http://schema.org/name": [
                     {
                       "@language": "en",
@@ -718,12 +663,7 @@
                   "@type": [
                     "http://schema.org/Boolean"
                   ],
-                  "http://schema.org/image": [
-                    {
-                      "@language": "en",
-                      "@value": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F44D.svg?sanitize=true"
-                    }
-                  ],
+                  "http://schema.org/image": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F44D.svg?sanitize=true",
                   "http://schema.org/name": [
                     {
                       "@language": "en",
@@ -749,7 +689,7 @@
               "@value": 0
             }
           ],
-          "http://schema.repronim.org/multipleChoice": [
+          "reprolib:terms/multipleChoice": [
             {
               "@type": "http://schema.org/Boolean",
               "@value": false
@@ -782,12 +722,7 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNEvening/items/health.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNEvening/items/health.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
@@ -824,12 +759,7 @@
                   "@type": [
                     "http://schema.org/Boolean"
                   ],
-                  "http://schema.org/image": [
-                    {
-                      "@language": "en",
-                      "@value": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F915.svg?sanitize=true"
-                    }
-                  ],
+                  "http://schema.org/image": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F915.svg?sanitize=true",
                   "http://schema.org/name": [
                     {
                       "@language": "en",
@@ -846,12 +776,7 @@
                   "@type": [
                     "http://schema.org/Boolean"
                   ],
-                  "http://schema.org/image": [
-                    {
-                      "@language": "en",
-                      "@value": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/263A.svg?sanitize=true"
-                    }
-                  ],
+                  "http://schema.org/image": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/263A.svg?sanitize=true",
                   "http://schema.org/name": [
                     {
                       "@language": "en",
@@ -877,7 +802,7 @@
               "@value": 0
             }
           ],
-          "http://schema.repronim.org/multipleChoice": [
+          "reprolib:terms/multipleChoice": [
             {
               "@type": "http://schema.org/Boolean",
               "@value": false
@@ -910,12 +835,7 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNEvening/items/negative_event.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNEvening/items/negative_event.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
@@ -993,7 +913,7 @@
               "@value": 0
             }
           ],
-          "http://schema.repronim.org/multipleChoice": [
+          "reprolib:terms/multipleChoice": [
             {
               "@type": "http://schema.org/Boolean",
               "@value": true
@@ -1026,12 +946,7 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNEvening/items/sources_of_stress.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNEvening/items/sources_of_stress.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
@@ -1068,12 +983,7 @@
                   "@type": [
                     "http://schema.org/option"
                   ],
-                  "http://schema.org/image": [
-                    {
-                      "@language": "en",
-                      "@value": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F915.svg?sanitize=true"
-                    }
-                  ],
+                  "http://schema.org/image": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F915.svg?sanitize=true",
                   "http://schema.org/name": [
                     {
                       "@language": "en",
@@ -1090,12 +1000,7 @@
                   "@type": [
                     "http://schema.org/option"
                   ],
-                  "http://schema.org/image": [
-                    {
-                      "@language": "en",
-                      "@value": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F469-200D-1F3EB.svg?sanitize=true"
-                    }
-                  ],
+                  "http://schema.org/image": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F469-200D-1F3EB.svg?sanitize=true",
                   "http://schema.org/name": [
                     {
                       "@language": "en",
@@ -1112,12 +1017,7 @@
                   "@type": [
                     "http://schema.org/option"
                   ],
-                  "http://schema.org/image": [
-                    {
-                      "@language": "en",
-                      "@value": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F4DD.svg?sanitize=true"
-                    }
-                  ],
+                  "http://schema.org/image": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F4DD.svg?sanitize=true",
                   "http://schema.org/name": [
                     {
                       "@language": "en",
@@ -1134,12 +1034,7 @@
                   "@type": [
                     "http://schema.org/option"
                   ],
-                  "http://schema.org/image": [
-                    {
-                      "@language": "en",
-                      "@value": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F47F.svg?sanitize=true"
-                    }
-                  ],
+                  "http://schema.org/image": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F47F.svg?sanitize=true",
                   "http://schema.org/name": [
                     {
                       "@language": "en",
@@ -1156,12 +1051,7 @@
                   "@type": [
                     "http://schema.org/option"
                   ],
-                  "http://schema.org/image": [
-                    {
-                      "@language": "en",
-                      "@value": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/E246.svg?sanitize=true"
-                    }
-                  ],
+                  "http://schema.org/image": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/E246.svg?sanitize=true",
                   "http://schema.org/name": [
                     {
                       "@language": "en",
@@ -1178,12 +1068,7 @@
                   "@type": [
                     "http://schema.org/option"
                   ],
-                  "http://schema.org/image": [
-                    {
-                      "@language": "en",
-                      "@value": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/2764.svg?sanitize=true"
-                    }
-                  ],
+                  "http://schema.org/image": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/2764.svg?sanitize=true",
                   "http://schema.org/name": [
                     {
                       "@language": "en",
@@ -1209,7 +1094,7 @@
               "@value": 0
             }
           ],
-          "http://schema.repronim.org/multipleChoice": [
+          "reprolib:terms/multipleChoice": [
             {
               "@type": "http://schema.org/Boolean",
               "@value": true
@@ -1242,12 +1127,7 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNEvening/items/stressful_day.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNEvening/items/stressful_day.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
@@ -1284,12 +1164,7 @@
                   "@type": [
                     "http://schema.org/Boolean"
                   ],
-                  "http://schema.org/image": [
-                    {
-                      "@language": "en",
-                      "@value": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F60A.svg?sanitize=true"
-                    }
-                  ],
+                  "http://schema.org/image": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F60A.svg?sanitize=true",
                   "http://schema.org/name": [
                     {
                       "@language": "en",
@@ -1306,12 +1181,7 @@
                   "@type": [
                     "http://schema.org/Boolean"
                   ],
-                  "http://schema.org/image": [
-                    {
-                      "@language": "en",
-                      "@value": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F630.svg?sanitize=true"
-                    }
-                  ],
+                  "http://schema.org/image": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F630.svg?sanitize=true",
                   "http://schema.org/name": [
                     {
                       "@language": "en",
@@ -1337,7 +1207,7 @@
               "@value": 0
             }
           ],
-          "http://schema.repronim.org/multipleChoice": [
+          "reprolib:terms/multipleChoice": [
             {
               "@type": "http://schema.org/Boolean",
               "@value": false
@@ -1370,12 +1240,7 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNMorning/items/nightmares.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNMorning/items/nightmares.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
@@ -1412,12 +1277,7 @@
                   "@type": [
                     "http://schema.org/Boolean"
                   ],
-                  "http://schema.org/image": [
-                    {
-                      "@language": "en",
-                      "@value": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F634.svg?sanitize=true"
-                    }
-                  ],
+                  "http://schema.org/image": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F634.svg?sanitize=true",
                   "http://schema.org/name": [
                     {
                       "@language": "en",
@@ -1434,12 +1294,7 @@
                   "@type": [
                     "http://schema.org/Boolean"
                   ],
-                  "http://schema.org/image": [
-                    {
-                      "@language": "en",
-                      "@value": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F62B.svg?sanitize=true"
-                    }
-                  ],
+                  "http://schema.org/image": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F62B.svg?sanitize=true",
                   "http://schema.org/name": [
                     {
                       "@language": "en",
@@ -1465,7 +1320,7 @@
               "@value": 0
             }
           ],
-          "http://schema.repronim.org/multipleChoice": [
+          "reprolib:terms/multipleChoice": [
             {
               "@type": "http://schema.org/Boolean",
               "@value": false
@@ -1498,12 +1353,7 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNMorning/items/sleeping_aids.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNMorning/items/sleeping_aids.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
@@ -1540,12 +1390,7 @@
                   "@type": [
                     "http://schema.org/Boolean"
                   ],
-                  "http://schema.org/image": [
-                    {
-                      "@language": "en",
-                      "@value": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F6CF.svg?sanitize=true"
-                    }
-                  ],
+                  "http://schema.org/image": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F6CF.svg?sanitize=true",
                   "http://schema.org/name": [
                     {
                       "@language": "en",
@@ -1562,12 +1407,7 @@
                   "@type": [
                     "http://schema.org/Boolean"
                   ],
-                  "http://schema.org/image": [
-                    {
-                      "@language": "en",
-                      "@value": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F48A.svg?sanitize=true"
-                    }
-                  ],
+                  "http://schema.org/image": "https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F48A.svg?sanitize=true",
                   "http://schema.org/name": [
                     {
                       "@language": "en",
@@ -1593,7 +1433,7 @@
               "@value": 0
             }
           ],
-          "http://schema.repronim.org/multipleChoice": [
+          "reprolib:terms/multipleChoice": [
             {
               "@type": "http://schema.org/Boolean",
               "@value": false
@@ -1626,12 +1466,7 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNMorning/items/time_in_bed.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/EmaHBNMorning/items/time_in_bed.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",

--- a/app/models/__tests__/json-ld.test.js
+++ b/app/models/__tests__/json-ld.test.js
@@ -44,18 +44,14 @@ test('flattenItemList', () => {
   const itemList = valueConstraints['http://schema.org/itemListElement'][0]['@list'];
   expect(flattenItemList(itemList)).toEqual([
     {
-      image: {
-        en: 'https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F634.svg?sanitize=true',
-      },
+      image: 'https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F634.svg?sanitize=true',
       name: {
         en: 'No',
       },
       value: 0,
     },
     {
-      image: {
-        en: 'https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F62B.svg?sanitize=true',
-      },
+      image: 'https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F62B.svg?sanitize=true',
       name: {
         en: 'Yes',
       },
@@ -73,18 +69,14 @@ test('flattenValueConstraints', () => {
     minValue: 0,
     itemList: [
       {
-        image: {
-          en: 'https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F634.svg?sanitize=true',
-        },
+        image: 'https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F634.svg?sanitize=true',
         name: {
           en: 'No',
         },
         value: 0,
       },
       {
-        image: {
-          en: 'https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F62B.svg?sanitize=true',
-        },
+        image: 'https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F62B.svg?sanitize=true',
         name: {
           en: 'Yes',
         },
@@ -104,9 +96,7 @@ test('appletTransformJson: ema-hbn', () => {
     about: {
       en: 'https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activity-sets/ema-hbn/README.md'
     },
-    image: {
-      en: 'https://childmindinstitute.github.io/mindlogger-assets/illustrations/undraw/hbn_ema_image.svg'
-    },
+    image: 'https://childmindinstitute.github.io/mindlogger-assets/illustrations/undraw/hbn_ema_image.svg',
     description: {
       en: "Daily questions about your child's physical and mental health",
     },
@@ -131,9 +121,7 @@ test('appletTransformJson: ema-hbn', () => {
     altLabel: {
       en: 'ema-hbn',
     },
-    schema: {
-      en: 'https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activity-sets/ema-hbn/ema-hbn_schema.jsonld'
-    },
+    schema: 'https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activity-sets/ema-hbn/ema-hbn_schema.jsonld',
     id: 'applet/5ca5314fd27b4e0459cee21f',
   };
 
@@ -240,9 +228,7 @@ test('itemTransformJson', () => {
       minValue: 0,
       itemList: [
         {
-          image: {
-            en: 'https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F634.svg?sanitize=true',
-          },
+          image: 'https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F634.svg?sanitize=true',
           name: {
             en: 'No',
           },
@@ -250,9 +236,7 @@ test('itemTransformJson', () => {
           valueConstraints: undefined,
         },
         {
-          image: {
-            en: 'https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F62B.svg?sanitize=true',
-          },
+          image: 'https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/color/svg/1F62B.svg?sanitize=true',
           name: {
             en: 'Yes',
           },

--- a/app/models/__tests__/nda-phq.json
+++ b/app/models/__tests__/nda-phq.json
@@ -18,12 +18,7 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/nda_guid.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/nda_guid.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
@@ -147,19 +142,14 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-8/phq8_schema.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-8/phq8_schema.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
           "@value": "0.0.1"
         }
       ],
-      "http://schema.repronim.org/preamble": [
+      "reprolib:terms/preamble": [
         {
           "@language": "en",
           "@value": "Over the last 2 weeks, how often have you been bothered by any of the following problems? (Use “✔” to indicate your answer)"
@@ -246,19 +236,14 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/phq9_schema.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/phq9_schema.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
           "@value": "0.0.1"
         }
       ],
-      "http://schema.repronim.org/preamble": [
+      "reprolib:terms/preamble": [
         {
           "@language": "en",
           "@value": "Over the last 2 weeks, how often have you been bothered by any of the following problems?"
@@ -536,19 +521,14 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/phq9a_schema.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/phq9a_schema.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
           "@value": "0.0.1"
         }
       ],
-      "http://schema.repronim.org/preamble": [
+      "reprolib:terms/preamble": [
         {
           "@language": "en",
           "@value": "Over the last 1 week, how often have you been bothered by any of the following problems? (Use “✔” to indicate your answer)"
@@ -641,19 +621,14 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/voice_task/voice_task_schema.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/voice_task/voice_task_schema.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
           "@value": "0.0.1"
         }
       ],
-      "http://schema.repronim.org/preamble": [
+      "reprolib:terms/preamble": [
         {
           "@language": "en",
           "@value": "For each task, you should hit the record button before speaking and then stop once you are done speaking. You may hit play to hear what was recorded."
@@ -741,12 +716,7 @@
         "@value": "0.0.1"
       }
     ],
-    "http://schema.org/url": [
-      {
-        "@language": "en",
-        "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activity-sets/example/nda-phq.jsonld"
-      }
-    ],
+    "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activity-sets/example/nda-phq.jsonld",
     "http://schema.org/version": [
       {
         "@language": "en",
@@ -818,12 +788,7 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/countryOfBirth.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/countryOfBirth.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
@@ -850,7 +815,7 @@
       ],
       "reprolib:terms/valueconstraints": [
         {
-          "http://schema.repronim.org/requiredValue": [
+          "reprolib:terms/required": [
             {
               "@type": "http://schema.org/Boolean",
               "@value": true
@@ -883,12 +848,7 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/gender.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/gender.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
@@ -966,13 +926,13 @@
               "@value": 0
             }
           ],
-          "http://schema.repronim.org/multipleChoice": [
+          "reprolib:terms/multipleChoice": [
             {
               "@type": "http://schema.org/Boolean",
               "@value": false
             }
           ],
-          "http://schema.repronim.org/requiredValue": [
+          "reprolib:terms/required": [
             {
               "@type": "http://schema.org/Boolean",
               "@value": true
@@ -1005,12 +965,7 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/healthCondition.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/healthCondition.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
@@ -1063,12 +1018,7 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/medication.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/medication.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
@@ -1121,12 +1071,7 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/mentalHealth.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/mentalHealth.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
@@ -1179,12 +1124,7 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/nativeLanguage.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/nativeLanguage.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
@@ -1211,7 +1151,7 @@
       ],
       "reprolib:terms/valueconstraints": [
         {
-          "http://schema.repronim.org/requiredValue": [
+          "reprolib:terms/required": [
             {
               "@type": "http://schema.org/Boolean",
               "@value": false
@@ -1244,12 +1184,7 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/raceEthnicity.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/raceEthnicity.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
@@ -1347,7 +1282,7 @@
               ]
             }
           ],
-          "http://schema.repronim.org/requiredValue": [
+          "reprolib:terms/required": [
             {
               "@type": "http://schema.org/Boolean",
               "@value": false
@@ -1380,12 +1315,7 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/state.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/state.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
@@ -1412,7 +1342,7 @@
       ],
       "reprolib:terms/valueconstraints": [
         {
-          "http://schema.repronim.org/requiredValue": [
+          "reprolib:terms/required": [
             {
               "@type": "http://schema.org/Boolean",
               "@value": false
@@ -1445,12 +1375,7 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/yearOfBirth.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/NDA/items/yearOfBirth.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
@@ -1483,7 +1408,7 @@
               "@value": "new Date()"
             }
           ],
-          "http://schema.repronim.org/requiredValue": [
+          "reprolib:terms/required": [
             {
               "@type": "http://schema.org/Boolean",
               "@value": true
@@ -1516,12 +1441,7 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-8/items/phq8_1.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-8/items/phq8_1.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
@@ -1576,12 +1496,7 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-8/items/phq8_2.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-8/items/phq8_2.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
@@ -1636,12 +1551,7 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-8/items/phq8_3.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-8/items/phq8_3.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
@@ -1696,12 +1606,7 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-8/items/phq8_4.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-8/items/phq8_4.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
@@ -1756,12 +1661,7 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-8/items/phq8_5.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-8/items/phq8_5.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
@@ -1816,12 +1716,7 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-8/items/phq8_6.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-8/items/phq8_6.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
@@ -1876,12 +1771,7 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-8/items/phq8_7.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-8/items/phq8_7.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
@@ -1936,12 +1826,7 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-8/items/phq8_8.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-8/items/phq8_8.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
@@ -1996,12 +1881,7 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_1.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_1.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
@@ -2056,12 +1936,7 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_10.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_10.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
@@ -2156,13 +2031,13 @@
               "@value": 0
             }
           ],
-          "http://schema.repronim.org/multipleChoice": [
+          "reprolib:terms/multipleChoice": [
             {
               "@type": "http://schema.org/Boolean",
               "@value": false
             }
           ],
-          "http://schema.repronim.org/requiredValue": [
+          "reprolib:terms/required": [
             {
               "@type": "http://schema.org/Boolean",
               "@value": false
@@ -2195,12 +2070,7 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_2.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_2.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
@@ -2255,12 +2125,7 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_3.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_3.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
@@ -2315,12 +2180,7 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_4.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_4.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
@@ -2375,12 +2235,7 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_5.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_5.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
@@ -2435,12 +2290,7 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_6.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_6.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
@@ -2495,12 +2345,7 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_7.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_7.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
@@ -2555,12 +2400,7 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_8.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_8.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
@@ -2615,12 +2455,7 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_9.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9/items/phq9_9.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
@@ -2675,12 +2510,7 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/items/phq9a_1.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/items/phq9a_1.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
@@ -2735,12 +2565,7 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/items/phq9a_10.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/items/phq9a_10.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
@@ -2795,12 +2620,7 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/items/phq9a_2.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/items/phq9a_2.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
@@ -2855,12 +2675,7 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/items/phq9a_3.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/items/phq9a_3.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
@@ -2915,12 +2730,7 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/items/phq9a_4.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/items/phq9a_4.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
@@ -2972,12 +2782,7 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/items/phq9a_5.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/items/phq9a_5.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
@@ -3032,12 +2837,7 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/items/phq9a_6.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/items/phq9a_6.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
@@ -3092,12 +2892,7 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/items/phq9a_7.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/items/phq9a_7.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
@@ -3152,12 +2947,7 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/items/phq9a_8.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/items/phq9a_8.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
@@ -3212,12 +3002,7 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/items/phq9a_9.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/PHQ-9a/items/phq9a_9.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
@@ -3272,12 +3057,7 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/voice_task/items/describe_image.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/voice_task/items/describe_image.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
@@ -3332,12 +3112,7 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/voice_task/items/free_speech.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/voice_task/items/free_speech.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
@@ -3374,13 +3149,13 @@
               "@value": 0
             }
           ],
-          "http://schema.repronim.org/multipleChoice": [
+          "reprolib:terms/multipleChoice": [
             {
               "@type": "http://schema.org/Boolean",
               "@value": false
             }
           ],
-          "http://schema.repronim.org/requiredValue": [
+          "reprolib:terms/required": [
             {
               "@type": "http://schema.org/Boolean",
               "@value": true
@@ -3413,12 +3188,7 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/voice_task/items/guided_speech.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/voice_task/items/guided_speech.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
@@ -3445,12 +3215,7 @@
       ],
       "reprolib:terms/valueconstraints": [
         {
-          "http://schema.org/image": [
-            {
-              "@language": "en",
-              "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/voice_task/map.png"
-            }
-          ],
+          "http://schema.org/image": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/voice_task/map.png",
           "http://schema.org/maxValue": [
             {
               "@value": 60000
@@ -3461,13 +3226,13 @@
               "@value": 0
             }
           ],
-          "http://schema.repronim.org/multipleChoice": [
+          "reprolib:terms/multipleChoice": [
             {
               "@type": "http://schema.org/Boolean",
               "@value": false
             }
           ],
-          "http://schema.repronim.org/requiredValue": [
+          "reprolib:terms/required": [
             {
               "@type": "http://schema.org/Boolean",
               "@value": true
@@ -3500,12 +3265,7 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/voice_task/items/pataka.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/voice_task/items/pataka.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
@@ -3560,19 +3320,14 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/voice_task/items/phonetic.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/voice_task/items/phonetic.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
           "@value": "0.0.1"
         }
       ],
-      "http://schema.repronim.org/preamble": [
+      "reprolib:terms/preamble": [
         {
           "@language": "en",
           "@value": "Read the passage below out loud while recording yourself."
@@ -3608,7 +3363,7 @@
               "@value": 0
             }
           ],
-          "http://schema.repronim.org/requiredValue": [
+          "reprolib:terms/required": [
             {
               "@type": "http://schema.org/Boolean",
               "@value": true
@@ -3641,19 +3396,14 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/voice_task/items/rainbow_passage.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/voice_task/items/rainbow_passage.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
           "@value": "0.0.1"
         }
       ],
-      "http://schema.repronim.org/preamble": [
+      "reprolib:terms/preamble": [
         {
           "@language": "en",
           "@value": "Read the passage below out loud while recording yourself."
@@ -3689,7 +3439,7 @@
               "@value": 0
             }
           ],
-          "http://schema.repronim.org/requiredValue": [
+          "reprolib:terms/required": [
             {
               "@type": "http://schema.org/Boolean",
               "@value": true
@@ -3722,12 +3472,7 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/voice_task/items/say_ah.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/voice_task/items/say_ah.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
@@ -3776,19 +3521,14 @@
           "@value": "0.0.1"
         }
       ],
-      "http://schema.org/url": [
-        {
-          "@language": "en",
-          "@value": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/voice_task/multipart_voice_schema.jsonld"
-        }
-      ],
+      "http://schema.org/url": "https://raw.githubusercontent.com/ReproNim/schema-standardization/master/activities/voice_task/multipart_voice_schema.jsonld",
       "http://schema.org/version": [
         {
           "@language": "en",
           "@value": "0.0.1"
         }
       ],
-      "http://schema.repronim.org/preamble": [
+      "reprolib:terms/preamble": [
         {
           "@language": "en",
           "@value": "Please record your voice while doing the following:"

--- a/app/models/json-ld.js
+++ b/app/models/json-ld.js
@@ -21,14 +21,14 @@ const ITEM_LIST_ELEMENT = 'http://schema.org/itemListElement';
 const MAX_VALUE = 'http://schema.org/maxValue';
 const MEDIA = 'reprolib:terms/media';
 const MIN_VALUE = 'http://schema.org/minValue';
-const MULTIPLE_CHOICE = 'http://schema.repronim.org/multipleChoice';
+const MULTIPLE_CHOICE = 'reprolib:terms/multipleChoice';
 const NAME = 'http://schema.org/name';
 const ORDER = 'reprolib:terms/order';
-const PREAMBLE = 'http://schema.repronim.org/preamble';
+const PREAMBLE = 'reprolib:terms/preamble';
 const PREF_LABEL = 'http://www.w3.org/2004/02/skos/core#prefLabel';
 const QUESTION = 'http://schema.org/question';
 const REFUSE_TO_ANSWER = 'reprolib:terms/refused_to_answer';
-const REQUIRED_VALUE = 'http://schema.repronim.org/requiredValue';
+const REQUIRED_VALUE = 'reprolib:terms/required';
 const SCHEMA_VERSION = 'http://schema.org/schemaVersion';
 const SCORING_LOGIC = 'reprolib:terms/scoringLogic';
 const SHUFFLE = 'reprolib:terms/shuffle';
@@ -66,7 +66,7 @@ export const flattenIdList = (list = []) => list.map(item => item['@id']);
 export const flattenItemList = (list = []) => list.map(item => ({
   name: languageListToObject(item[NAME]),
   value: R.path([VALUE, 0, '@value'], item),
-  image: languageListToObject(item[IMAGE]),
+  image: item[IMAGE],
   valueConstraints: item[VALUE_CONSTRAINTS]
     ? flattenValueConstraints(R.path([VALUE_CONSTRAINTS, 0], item))
     : undefined,
@@ -159,24 +159,6 @@ export const isSkippable = (allowList) => {
   return false;
 };
 
-export const appletTransformJson = appletJson => ({
-  id: appletJson._id,
-  groupId: appletJson.groups,
-  schema: languageListToObject(appletJson[URL]),
-  name: languageListToObject(appletJson[PREF_LABEL]),
-  description: languageListToObject(appletJson[DESCRIPTION]),
-  about: languageListToObject(appletJson[ABOUT]),
-  schemaVersion: languageListToObject(appletJson[SCHEMA_VERSION]),
-  version: languageListToObject(appletJson[VERSION]),
-  altLabel: languageListToObject(appletJson[ALT_LABEL]),
-  visibility: listToObject(appletJson[VISIBILITY]),
-  image: languageListToObject(appletJson[IMAGE]),
-  order: flattenIdList(appletJson[ORDER][0]['@list']),
-  schedule: appletJson.schedule,
-  responseDates: appletJson.responseDates,
-  shuffle: R.path([SHUFFLE, 0, '@value'], appletJson),
-});
-
 export const itemTransformJson = (itemJson) => {
   // For items, 'skippable' is undefined if there's no ALLOW prop
   const allowList = flattenIdList(R.path([ALLOW, 0, '@list'], itemJson));
@@ -247,9 +229,7 @@ export const activityTransformJson = (activityJson, itemsJson) => {
   const variableMapAr = R.pathOr([], [VARIABLE_MAP, 0, '@list'], activityJson);
   const variableMap = transformVariableMap(variableMapAr);
   const visibility = listToObject(activityJson[VISIBILITY]);
-
   const preamble = languageListToObject(activityJson[PREAMBLE]);
-
   const order = flattenIdList(activityJson[ORDER][0]['@list']);
 
   const mapItems = R.map((itemKey) => {
@@ -276,6 +256,26 @@ export const activityTransformJson = (activityJson, itemsJson) => {
     notification,
     info,
     items,
+  };
+};
+
+export const appletTransformJson = (appletJson) => {
+  return {
+    id: appletJson._id,
+    groupId: appletJson.groups,
+    schema: appletJson.url || appletJson[URL],
+    name: languageListToObject(appletJson[PREF_LABEL]),
+    description: languageListToObject(appletJson[DESCRIPTION]),
+    about: languageListToObject(appletJson[ABOUT]),
+    schemaVersion: languageListToObject(appletJson[SCHEMA_VERSION]),
+    version: languageListToObject(appletJson[VERSION]),
+    altLabel: languageListToObject(appletJson[ALT_LABEL]),
+    visibility: listToObject(appletJson[VISIBILITY]),
+    image: appletJson[IMAGE],
+    order: flattenIdList(appletJson[ORDER][0]['@list']),
+    schedule: appletJson.schedule,
+    responseDates: appletJson.responseDates,
+    shuffle: R.path([SHUFFLE, 0, '@value'], appletJson),
   };
 };
 

--- a/app/widgets/AudioRecord/AudioImageRecord.js
+++ b/app/widgets/AudioRecord/AudioImageRecord.js
@@ -16,7 +16,7 @@ export class AudioImageRecord extends Component {
       <View style={{ paddingBottom: 16 }}>
         <Image
           style={{ width: '100%', height: 260, resizeMode: 'contain', marginBottom: 16 }}
-          source={{ uri: getURL(config.image.en) }}
+          source={{ uri: getURL(config.image) }}
         />
         <AudioRecorder
           onStop={this.onRecord}
@@ -36,7 +36,7 @@ AudioImageRecord.propTypes = {
     uri: PropTypes.string,
   }),
   config: PropTypes.shape({
-    image: PropTypes.object,
+    image: PropTypes.string,
   }).isRequired,
   onChange: PropTypes.func.isRequired,
 };

--- a/app/widgets/MultiSelect.js
+++ b/app/widgets/MultiSelect.js
@@ -46,7 +46,7 @@ export class MultiSelect extends Component {
                     ? (
                       <Image
                         style={{ width: 64, height: 64, resizeMode: 'cover' }}
-                        source={{ uri: getURL(item.image.en) }}
+                        source={{ uri: getURL(item.image) }}
                       />
                     ) : <View />
                   }

--- a/app/widgets/Radio.js
+++ b/app/widgets/Radio.js
@@ -22,7 +22,7 @@ export const Radio = ({ value, config, onChange }) => (
                 ? (
                   <Image
                     style={{ width: 64, height: 64, resizeMode: 'cover' }}
-                    source={{ uri: getURL(item.image.en) }}
+                    source={{ uri: getURL(item.image) }}
                   />
                 ) : <View />
               }
@@ -54,7 +54,7 @@ Radio.propTypes = {
     itemList: PropTypes.arrayOf(PropTypes.shape({
       name: PropTypes.object,
       value: PropTypes.any,
-      image: PropTypes.object,
+      image: PropTypes.string,
     })).isRequired,
   }).isRequired,
   onChange: PropTypes.func.isRequired,

--- a/app/widgets/Slider/index.js
+++ b/app/widgets/Slider/index.js
@@ -15,7 +15,7 @@ export const Slider = ({
 }) => (
   <View style={{ alignItems: 'stretch', minHeight: 450 }}>
     <Text style={{ textAlign: 'center' }}>{maxValue}</Text>
-    { itemList[itemList.length - 1].image ? <View style={{ justifyContent: 'center', alignItems: 'center' }}><Image style={{ width: 45, height: 45, resizeMode: 'cover' }} source={{ uri: getURL(itemList[itemList.length - 1].image.en) }} /></View> : <View />}
+    { itemList[itemList.length - 1].image ? <View style={{ justifyContent: 'center', alignItems: 'center' }}><Image style={{ width: 45, height: 45, resizeMode: 'cover' }} source={{ uri: getURL(itemList[itemList.length - 1].image) }} /></View> : <View />}
     <SliderComponent
       value={value || 0}
       /**
@@ -31,7 +31,7 @@ export const Slider = ({
       onPress={onPress}
       onRelease={onRelease}
     />
-    { itemList[0].image ? <View style={{ justifyContent: 'center', alignItems: 'center' }}><Image style={{ width: 45, height: 45, resizeMode: 'cover' }} source={{ uri: getURL(itemList[0].image.en) }} /></View> : <View />}
+    { itemList[0].image ? <View style={{ justifyContent: 'center', alignItems: 'center' }}><Image style={{ width: 45, height: 45, resizeMode: 'cover' }} source={{ uri: getURL(itemList[0].image) }} /></View> : <View />}
     <Text style={{ textAlign: 'center' }}>{minValue}</Text>
   </View>
 );

--- a/app/widgets/VisualStimulusResponse/README.md
+++ b/app/widgets/VisualStimulusResponse/README.md
@@ -20,7 +20,7 @@ The `VisualStimulusResponse` widget accepts a `config` object. The `config` obje
 
 ```js
 trials: PropTypes.arrayOf(PropTypes.shape({
-  image: PropTypes.object,
+  image: PropTypes.string,
   valueConstraints: PropTypes.object,
   value: PropTypes.number,
   weight: PropTypes.number,

--- a/app/widgets/VisualStimulusResponse/index.js
+++ b/app/widgets/VisualStimulusResponse/index.js
@@ -58,7 +58,7 @@ export const VisualStimulusResponse = ({ onChange, config, isCurrent }) => {
 VisualStimulusResponse.propTypes = {
   config: PropTypes.shape({
     trials: PropTypes.arrayOf(PropTypes.shape({
-      image: PropTypes.object,
+      image: PropTypes.string,
       valueConstraints: PropTypes.object,
       value: PropTypes.number,
       weight: PropTypes.number,

--- a/ios/MDCApp/Info.plist
+++ b/ios/MDCApp/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.8.7</string>
+	<string>0.8.8</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>90</string>
+	<string>91</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
  "name": "MindLogger",
- "version": "0.8.7",
+ "version": "0.8.8",
  "private": true,
  "scripts": {
   "start": "node node_modules/react-native/local-cli/cli.js start",


### PR DESCRIPTION
* `http://schema.repronim.org` prefix replaced by reprolib
* `http://schema.org/url` and `http://schema.org/image` are now string values rather than a language lists
* `applet.schema` is set as either `url` or `http://schema.org/url` with `url` taking precedence
* `requiredValue` renamed to `required`