### PR TITLE
🚑 Don't crash if responseDates is undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 =======
+## [0.9.8] - 2019-12-10
+### Fixed
+- :ambulance: Don't crash if responseDates is undefined 
+
 ## [0.9.7] - 2019-12-10
 ### Updated
 - :arrow_up: react-native-webview@5→7

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MindLogger 0.9.7
+# MindLogger 0.9.8
 
 _Note: v0.1 is deprecated as of June 12, 2019._
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -101,8 +101,8 @@ android {
         applicationId "lab.childmindinstitute.data"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 100
-        versionName "0.9.7"
+        versionCode 101
+        versionName "0.9.8"
         ndk {
             abiFilters "arm64-v8a", "x86_64", "armeabi-v7a", "x86"
         }

--- a/app/scenes/AppletDetails/AppletDetailsComponent.js
+++ b/app/scenes/AppletDetails/AppletDetailsComponent.js
@@ -72,7 +72,7 @@ class AppletDetailsComponent extends React.Component {
       appletData,
     } = this.props;
 
-    const responseDates = this.getResponseDates();
+    const responseDates = this.getResponseDates() || [];
 
     switch (selectedTab) {
       case 'survey':

--- a/ios/MDCApp/Info.plist
+++ b/ios/MDCApp/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.9.7</string>
+	<string>0.9.8</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>100</string>
+	<string>101</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
  "name": "MindLogger",
- "version": "0.9.7",
+ "version": "0.9.8",
  "private": true,
  "scripts": {
   "start": "node node_modules/react-native/local-cli/cli.js start",


### PR DESCRIPTION
For https://github.com/ChildMindInstitute/MindLogger-bug-reports/issues/70, I'm working on restoring the `responseDates` key (which I didn't realize was relied upon in the mobile app when I was refactoring). It's a bit of work to update it because it involves changes in all of the recent backend refactors (user model, schema structure, nested activities, and large protocols); this patch to the mobile app will just not show dots on the but otherwise work as expected rather than crashing when clicking an applet à la https://github.com/ChildMindInstitute/mindlogger-app/issues/319#issuecomment-563621558.