### PR TITLE
🚑 Resolve some breaking changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 =======
+## [0.9.9]‒[0.9.10] - 2019-12-17
+- :lipstick: More invasive notifications
+
 ## [0.9.8] - 2019-12-10
 ### Fixed
-- :ambulance: Don't crash if responseDates is undefined 
+- :ambulance: Don't crash if responseDates is undefined
 
 ## [0.9.7] - 2019-12-10
 ### Updated

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MindLogger 0.9.9
+# MindLogger 0.9.10
 
 _Note: v0.1 is deprecated as of June 12, 2019._
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -101,8 +101,8 @@ android {
         applicationId "lab.childmindinstitute.data"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 102
-        versionName "0.9.9"
+        versionCode 103
+        versionName "0.9.10"
         ndk {
             abiFilters "arm64-v8a", "x86_64", "armeabi-v7a", "x86"
         }

--- a/app/setup.js
+++ b/app/setup.js
@@ -13,15 +13,15 @@ import { setCurrentActivity, setCurrentApplet } from './state/app/app.actions';
 import { startFreshResponse } from './state/responses/responses.thunks';
 import { currentAppletSelector } from './state/app/app.selectors';
 
+const resetBaseCount = () => {
+  PushNotificationIOS.setApplicationIconBadgeNumber(0)
+}
+
 const checkAuthToken = (store) => {
   const state = store.getState();
   if (state.user.auth === null) {
     store.dispatch(clearUser()); // Just in case
     return false;
-  }
-
-  const resetBaseCount = () => {
-    PushNotificationIOS.setApplicationIconBadgeNumber(0)
   }
 
   const authExpiration = moment(state.user.auth.expires);

--- a/app/setup.js
+++ b/app/setup.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Platform } from 'react-native';
+import { Platform, PushNotificationIOS } from 'react-native';
 import { Provider } from 'react-redux';
 import { Root } from 'native-base';
 import { Actions } from 'react-native-router-flux';

--- a/ios/MDCApp/Info.plist
+++ b/ios/MDCApp/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.9.9</string>
+	<string>0.9.10</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>102</string>
+	<string>103</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "MindLogger",
-    "version": "0.9.9",
+    "version": "0.9.10",
     "private": true,
     "scripts": {
         "start": "node node_modules/react-native/local-cli/cli.js start",


### PR DESCRIPTION
[v0.9.9](https://github.com/ChildMindInstitute/mindlogger-app/releases/tag/v0.9.9) (#325) included a couple breaking changes: 

- `resetBaseCount` could be called from beyond a scope in which it was defined
- `PushNotificationIOS` was not imported in `app/setup.js` but was called

This PR resolves those issues.