### PR TITLE
Adding flag to set Lock Screen Notifications on Push Notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 =======
+## [0.9.12] - 2020-01-07
+### Added
+- :sparkles: Addig flag to request Lock Screen Notifications for Push Notifications
+
 ## [0.9.10]‒[0.9.11] - 2019-12-17
 - :lipstick: Fix font size scaling from device's settings
 - :lipstick: Change radio and checkbox buttons appearance

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -101,8 +101,8 @@ android {
         applicationId "lab.childmindinstitute.data"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 104
-        versionName "0.9.11"
+        versionCode 105
+        versionName "0.9.12"
         ndk {
             abiFilters "arm64-v8a", "x86_64", "armeabi-v7a", "x86"
         }

--- a/app/services/pushNotifications.js
+++ b/app/services/pushNotifications.js
@@ -17,6 +17,7 @@ export const initializePushNotifications = (onNotification) => {
       alert: true,
       badge: true,
       sound: true,
+      lockScreen: true,
     },
     visibility: 'public',
     popInitialNotification: true,

--- a/ios/MDCApp/Info.plist
+++ b/ios/MDCApp/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.9.11</string>
+	<string>0.9.12</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>104</string>
+	<string>105</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "MindLogger",
-    "version": "0.9.11",
+    "version": "0.9.12",
     "private": true,
     "scripts": {
         "start": "node node_modules/react-native/local-cli/cli.js start",


### PR DESCRIPTION
Adding flag to set Lock Screen Notifications on Push Notifications: On file `app/services/pushNotifications.js` I added the flag `lockScreen: true,` so the user will authorize Push Notifications on Lock Screen when the app is installed for the first time.