### PR TITLE
Fix DatePickerIOS doesn't show on Dark Mode for iOS 13.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 =======
+## [0.9.13] - 2019-01-08
+- :bug: Fix DatePickerIOS doesn't show on Dark Mode for iOS 13.3
+
 ## [0.9.10]‒[0.9.11] - 2019-12-17
 - :lipstick: Fix font size scaling from device's settings
 - :lipstick: Change radio and checkbox buttons appearance

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -101,8 +101,8 @@ android {
         applicationId "lab.childmindinstitute.data"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 104
-        versionName "0.9.11"
+        versionCode 106
+        versionName "0.9.13"
         ndk {
             abiFilters "arm64-v8a", "x86_64", "armeabi-v7a", "x86"
         }

--- a/ios/MDCApp/Info.plist
+++ b/ios/MDCApp/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.9.11</string>
+	<string>0.9.13</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>104</string>
+	<string>106</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>
@@ -103,5 +103,7 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 </dict>
 </plist>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "MindLogger",
-    "version": "0.9.11",
+    "version": "0.9.13",
     "private": true,
     "scripts": {
         "start": "node node_modules/react-native/local-cli/cli.js start",


### PR DESCRIPTION
Added:
`<key>UIUserInterfaceStyle</key>`
`<string>Light</string>`
to Info.plist to enforce Light Mode on the app even if iPhone is in Dark Mode. Know bug about iOS 13.3 where DatePickers doesn't show on Dark Mode. https://github.com/xgfe/react-native-datepicker/issues/365