### PR TITLE
Widget Image Sizing Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+## [0.11.31] - 2019-5-3
+- Change ```resizeMode``` property of images in widgets to prevent sides from being cut off
+
 ## [0.11.28] - 2019-4-28
 - Fixd Notification Badge Issue
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MindLogger 0.11.28
+# MindLogger 0.11.31
 
 _Note: v0.1 is deprecated as of June 12, 2019._
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -130,8 +130,8 @@ android {
         applicationId "lab.childmindinstitute.data"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 145
-        versionName "0.11.28"
+        versionCode 148
+        versionName "0.11.31"
         missingDimensionStrategy 'react-native-camera', 'general'
         multiDexEnabled true
     }

--- a/app/scenes/Settings/index.js
+++ b/app/scenes/Settings/index.js
@@ -64,7 +64,11 @@ class SettingsScreen extends React.Component {
           }
 
           <List>
-            <ListItem button bordered onPress={() => Actions.push('change_password')}>
+            <ListItem
+              button
+              bordered
+              onPress={() => Actions.push('change_password')}
+            >
               <Left>
                 <Text>Change Password</Text>
               </Left>
@@ -72,7 +76,10 @@ class SettingsScreen extends React.Component {
                 <Icon name="arrow-forward" />
               </Right>
             </ListItem>
-            <ListItem bordered>
+            <ListItem
+              button
+              bordered
+            >
               <Left>
                 <Text>Use Cellular Data</Text>
               </Left>
@@ -83,22 +90,25 @@ class SettingsScreen extends React.Component {
                 />
               </Right>
             </ListItem>
-            <ListItem onPress={() => {
-              logout();
-            }}
+            <ListItem
+              button
+              bordered
+              onPress={() => logout()}
             >
               <Left>
-                <Text> Logout </Text>
+                <Text>Logout</Text>
               </Left>
               <Right>
                 <Icon name="key" />
               </Right>
             </ListItem>
-            <ListItem 
+            <ListItem
+              button
+              bordered
               onPress={() => this.showAlert()}
             >
               <Left>
-                <Text> Permanently Delete Account </Text>
+                <Text>Permanently Delete Account</Text>
               </Left>
               <Right>
                 <Icon name="trash" />

--- a/app/widgets/Drawing/DrawingBoard.js
+++ b/app/widgets/Drawing/DrawingBoard.js
@@ -9,7 +9,7 @@ const styles = StyleSheet.create({
   picture: {
     width: '100%',
     height: '100%',
-    resizeMode: 'cover',
+    resizeMode: 'contain',
   },
   blank: {
     width: '100%',

--- a/app/widgets/MultiSelect.js
+++ b/app/widgets/MultiSelect.js
@@ -44,7 +44,7 @@ export class MultiSelect extends Component {
               <View style={{ width: '100%', flexDirection: 'row' }}>
                 {item.image ? (
                   <Image
-                    style={{ width: '20%', height: 64, resizeMode: 'cover' }}
+                    style={{ width: '20%', height: 64, resizeMode: 'contain' }}
                     source={{ uri: getURL(item.image) }}
                   />
                 ) : (

--- a/app/widgets/Radio.js
+++ b/app/widgets/Radio.js
@@ -18,7 +18,7 @@ export const Radio = ({ value, config, onChange }) => (
           <View style={{ width: '100%', flexDirection: 'row' }}>
             {item.image ? (
               <Image
-                style={{ width: '20%', height: 64, resizeMode: 'cover' }}
+                style={{ width: '20%', height: 64, resizeMode: 'contain' }}
                 source={{ uri: getURL(item.image) }}
               />
             ) : (

--- a/app/widgets/Slider/index.js
+++ b/app/widgets/Slider/index.js
@@ -67,7 +67,7 @@ const styles = StyleSheet.create({
   icon: {
     width: 45,
     height: 45,
-    resizeMode: 'cover',
+    resizeMode: 'contain',
   },
   labelContainer: {
     width: '100%',

--- a/ios/MDCApp/Info.plist
+++ b/ios/MDCApp/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.11.28</string>
+	<string>0.11.30</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>145</string>
+	<string>147</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "MindLogger",
-    "version": "0.11.28",
+    "version": "0.11.31",
     "private": true,
     "scripts": {
         "start": "node node_modules/react-native/local-cli/cli.js start",


### PR DESCRIPTION
- Change ```resizeMode``` property of images in widgets to prevent sides from being cut off
- Fix some styling in ```app/scenes/Settings/index.js``` for better code consistency
- Fixes #828 
- NOTE: this makes non-square images a bit smaller. Before & after:
![diff](https://user-images.githubusercontent.com/31543235/80923783-4c46e680-8d4b-11ea-8edd-13e9f65d6ec0.png)
